### PR TITLE
Add ISO week of encounter to incidence model observation view

### DIFF
--- a/schema/deploy/shipping/views@2019-04-19.sql
+++ b/schema/deploy/shipping/views@2019-04-19.sql
@@ -14,14 +14,11 @@ begin;
 -- there needs to be a lag between view development and consumers being
 -- updated, copy the view definition into v2 and make changes there.
 
-drop view shipping.incidence_model_observation_v1;
-
-create view shipping.incidence_model_observation_v1 as
+create or replace view shipping.incidence_model_observation_v1 as
 
     select encounter.identifier as encounter,
 
            (encountered at time zone 'US/Pacific')::date as encountered_date,
-           to_char((encountered at time zone 'US/Pacific')::date, 'IYYY-"W"IW') as encountered_week,
 
            site.details->>'type' as site_type,
 

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -1,7 +1,99 @@
--- Revert seattleflu/schema:shipping/views from pg
+-- Deploy seattleflu/schema:shipping/views to pg
+-- requires: shipping/schema
+-- requires: functions/array_distinct
+
+-- Hello!  All shipping views are defined here.  Rework this change with Sqitch
+-- to change a view definition or add new views.  This workflow helps keep
+-- inter-view dependencies manageable.
 
 begin;
 
+-- This view is versioned as a hedge against future changes.  Changing this
+-- view in place is fine as long as changes are backwards compatible.  Think of
+-- the version number as the major part of a semantic versioning scheme.  If
+-- there needs to be a lag between view development and consumers being
+-- updated, copy the view definition into v2 and make changes there.
+
 drop view shipping.incidence_model_observation_v1;
+
+create view shipping.incidence_model_observation_v1 as
+
+    select encounter.identifier as encounter,
+
+           (encountered at time zone 'US/Pacific')::date as encountered_date,
+
+           site.details->>'type' as site_type,
+
+           individual.identifier as individual,
+           individual.sex,
+
+           -- Reporting 90 is more accurate than reporting nothing, and it will
+           -- never be a real value in our dataset.
+           --
+           -- XXX TODO: This will be pre-processed out of the JSON in the future.
+           case (encounter.details->'age'->>'ninetyOrAbove')::bool
+             when true
+             then 90
+             else (encounter.details->'age'->>'value')::int
+           end as age,
+
+           -- XXX TODO: This will be pre-processed out of the JSON in the future.
+           case (encounter.details->'locations'->'temp') is not null
+             when true
+             then encounter.details->'locations'->'temp'->>'region'
+             else encounter.details->'locations'->'home'->>'region'
+           end as residence_census_tract,
+
+           -- XXX TODO: This will be pre-processed out of the JSON in the future.
+           encounter.details->'locations'->'work'->>'region' as work_census_tract,
+
+           encounter_responses.flu_shot,
+           encounter_responses.symptoms,
+           encounter_responses.race,
+           encounter_responses.hispanic_or_latino
+
+      from warehouse.encounter
+      join warehouse.individual using (individual_id)
+      join warehouse.site using (site_id),
+
+      lateral (
+          -- XXX TODO: The data in this subquery will be modeled better in the
+          -- future and the verbosity of extracting data from the JSON details
+          -- document will go away.
+          --   -trs, 22 March 2019
+
+          select -- XXX FIXME: Remove use of nullif() when we're no longer
+                 -- dealing with raw response values.
+                 nullif(responses."FluShot"[1], 'doNotKnow')::bool as flu_shot,
+
+                 -- XXX FIXME: Remove duplicate value collapsing when we're no
+                 -- longer affected by this known Audere data quality issue.
+                 array_distinct(responses."Symptoms") as symptoms,
+                 array_distinct(responses."Race") as race,
+
+                 -- XXX FIXME: Remove use of nullif() when we're no longer
+                 -- dealing with raw response values.
+                 nullif(responses."HispanicLatino"[1], 'preferNotToSay')::bool as hispanic_or_latino
+
+            from jsonb_to_record(encounter.details->'responses')
+              as responses (
+                  "FluShot" text[],
+                  "Symptoms" text[],
+                  "Race" text[],
+                  "HispanicLatino" text[]))
+        as encounter_responses
+
+     order by encountered;
+
+comment on view shipping.incidence_model_observation_v1 is
+    'View of warehoused encounters and important questionnaire responses for modeling and viz teams';
+
+revoke all
+    on shipping.incidence_model_observation_v1
+  from "incidence-modeler";
+
+grant select
+   on shipping.incidence_model_observation_v1
+   to "incidence-modeler";
 
 commit;

--- a/schema/revert/shipping/views@2019-04-19.sql
+++ b/schema/revert/shipping/views@2019-04-19.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:shipping/views from pg
+
+begin;
+
+drop view shipping.incidence_model_observation_v1;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -36,3 +36,5 @@ receiving/presence-absence [receiving/schema] 2019-04-08T22:27:17Z Thomas Sibley
 receiving/sequence-read-set [receiving/schema] 2019-04-09T23:31:36Z Thomas Sibley <tsibley@fredhutch.org> # Receiving table for sequence read set references
 roles/diagnostic-lab [receiving/presence-absence] 2019-04-10T20:28:40Z Thomas Sibley <tsibley@fredhutch.org> # Role for reporting of diagnostic results
 roles/sequencing-lab [receiving/sequence-read-set] 2019-04-10T20:32:42Z Thomas Sibley <tsibley@fredhutch.org> # Role for reporting sequencing results
+@2019-04-19 2019-04-19T20:51:52Z Thomas Sibley <tsibley@fredhutch.org> # Deployed schema as of 19 April 2019
+shipping/views [shipping/views@2019-04-19] 2019-04-19T21:08:30Z Thomas Sibley <tsibley@fredhutch.org> # Add ISO week to incidence model observations

--- a/schema/verify/shipping/views@2019-04-19.sql
+++ b/schema/verify/shipping/views@2019-04-19.sql
@@ -1,0 +1,10 @@
+-- Verify seattleflu/schema:shipping/views on pg
+
+begin;
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v1');
+
+rollback;


### PR DESCRIPTION
Time binning is useful for the modeling and viz efforts, so it's nice to
harmonize that early in the data flow rather than separately several
times.  Weeks are the standard time bin used in epidemiology.

Note that the WHO's epi weeks, synonymous with ISO weeks, are slightly
different from CDC's epi weeks, as described most succinctly¹

> The US CDC defines epidemiological week (known as MMWR week) as seven
> days beginning with Sunday and ending with Saturday. The WHO defines
> epidemiological week, based on ISO week, as seven days beginning with
> Monday and ending with Sunday. In either case, the end of the first
> epidemiological week of the year by definition must fall at least four
> days into the year. Most years have 52 epidemiological weeks, but some
> have 53.

It's my understanding that WHO / ISO weeks are used more widely around
the world, and just like we use the metric system in science, it seems
we should use international datetime standards as well.

If we find ourselves wanting CDC epi weeks in the future, we can add
them as well.

¹ https://epiweeks.readthedocs.io