### PR TITLE
identifier labels: Make labels for existing batches of identifiers

### DIFF
--- a/lib/seattleflu/labelmaker.py
+++ b/lib/seattleflu/labelmaker.py
@@ -152,7 +152,6 @@ def generate_pdf(layout: LabelLayout, api: str = DEFAULT_LABEL_API) -> bytes:
     spec = json.dumps(layout.spec())
 
     LOG.info(f"Generating PDF using Lab Labels API at {api}")
-    LOG.debug(f"Label layout spec: {spec}")
 
     response = requests.post(f"{api}/stickers",
         headers = { "Content-Type": "application/json" },


### PR DESCRIPTION
This is useful if you forget to pass --labels to `identifier mint`, you
lose the original PDF, or if the identifier generation succeeds but
label-making fails for some reason.  I found myself in the last scenario
just now, so whipped this up instead of creating a one-off script to do
it.

Eventually the SQL queries in this command may want to be wrapped up
into a separate business logic layer (e.g. similar to
seattleflu.api.datastore vs. seattleflu.db.DatabaseSession).