### PR TITLE
Grant incidence-modeler select on shipping.age_bin_{fine,coarse}

### DIFF
--- a/schema/deploy/roles/incidence-modeler/grant-select-on-age-bins.sql
+++ b/schema/deploy/roles/incidence-modeler/grant-select-on-age-bins.sql
@@ -1,0 +1,12 @@
+-- Deploy seattleflu/schema:roles/incidence-modeler/grant-select-on-age-bins to pg
+-- requires: roles/incidence-modeler
+-- requires: shipping/age-bin
+
+begin;
+
+grant select
+   on table shipping.age_bin_fine,
+            shipping.age_bin_coarse
+   to "incidence-modeler";
+
+commit;

--- a/schema/revert/roles/incidence-modeler/grant-select-on-age-bins.sql
+++ b/schema/revert/roles/incidence-modeler/grant-select-on-age-bins.sql
@@ -1,0 +1,10 @@
+-- Revert seattleflu/schema:roles/incidence-modeler/grant-select-on-age-bins from pg
+
+begin;
+
+revoke select
+    on table shipping.age_bin_fine,
+             shipping.age_bin_coarse
+  from "incidence-modeler";
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -45,3 +45,4 @@ warehouse/presence_absence [warehouse/sample warehouse/target] 2019-04-22T22:54:
 shipping/age-bin 2019-04-30T23:36:59Z Jover Lee <joverlee@fredhutch.org> # Table representing age bins for incidence model views
 @2019-05-01 2019-05-01T19:18:36Z Jover Lee <joverlee@fredhutch.org> # Deployed schema as of 01 May 2019
 shipping/views [shipping/views@2019-05-01] 2019-05-01T19:21:04Z Jover Lee <joverlee@fredhutch.org> # Add age bins to incidence model observations
+roles/incidence-modeler/grant-select-on-age-bins [roles/incidence-modeler shipping/age-bin] 2019-05-02T23:29:20Z Thomas Sibley <tsibley@fredhutch.org> # Grant incidence modelers select on shipping.age_bin_*

--- a/schema/verify/roles/incidence-modeler/grant-select-on-age-bins.sql
+++ b/schema/verify/roles/incidence-modeler/grant-select-on-age-bins.sql
@@ -1,0 +1,10 @@
+-- Verify seattleflu/schema:roles/incidence-modeler/grant-select-on-age-bins on pg
+
+begin;
+
+do $$ begin
+    assert pg_catalog.has_table_privilege('incidence-modeler', 'shipping.age_bin_fine', 'select');
+    assert pg_catalog.has_table_privilege('incidence-modeler', 'shipping.age_bin_coarse', 'select');
+end $$;
+
+rollback;


### PR DESCRIPTION
This lets them pull the full set of ranges possible for modeling
purposes, even if the data doesn't cover all bins.