### PR TITLE
Allow bin/id3c to be invoked without pipenv

### DIFF
--- a/bin/id3c
+++ b/bin/id3c
@@ -1,13 +1,22 @@
-#!/usr/bin/env python3
-from sys import argv, path, exit
-from pathlib import Path
+#!/bin/bash
+set -euo pipefail
 
-# Add our containing repo's lib directory to the Python module search path so
-# that we can load seattleflu.db.
-libpath = Path(__file__).parent.parent / "lib"
-assert libpath.is_dir()
+# Find our project root.
+root="$(cd "$(dirname "$0")/.." && pwd)"
 
-path.insert(0, str(libpath))
+# Add our lib dir to the module search path so we can load seattleflu.db.
+locallib="$root/lib"
+test -d "$locallib"
+export PYTHONPATH="$locallib"
 
-from seattleflu.db.cli.__main__ import cli
-exit(cli(argv[1:]))
+if [[ -n ${PIPENV_ACTIVE:-} ]]; then
+    # We are already running under `pipenv run` or `pipenv shell`.
+    exec python3 -m seattleflu.db.cli "$@"
+else
+    # We need to run under pipenv, so find our Pipfile.
+    pipfile="$root/Pipfile"
+    test -e "$pipfile"
+    export PIPENV_PIPFILE="$pipfile"
+
+    exec pipenv run python3 -m seattleflu.db.cli "$@"
+fi

--- a/lib/seattleflu/db/cli/__init__.py
+++ b/lib/seattleflu/db/cli/__init__.py
@@ -1,0 +1,16 @@
+"""
+A command-line interface to the Infectious Disease Data Distribution Center.
+"""
+import click
+from typing import NoReturn
+
+
+# Invoked by bin/id3c
+@click.group(help = __doc__)
+def cli() -> NoReturn:
+    pass
+
+
+# Load all top-level seattleflu.db.cli.command packages, giving them an
+# opportunity to register their commands using @cli.command(…).
+from .command import *

--- a/lib/seattleflu/db/cli/__init__.py
+++ b/lib/seattleflu/db/cli/__init__.py
@@ -5,7 +5,7 @@ import click
 from typing import NoReturn
 
 
-# Invoked by bin/id3c
+# Base command for all other commands
 @click.group(help = __doc__)
 def cli() -> NoReturn:
     pass

--- a/lib/seattleflu/db/cli/__main__.py
+++ b/lib/seattleflu/db/cli/__main__.py
@@ -1,21 +1,7 @@
 """
-A command-line interface to the Infectious Disease Data Distribution Center.
+Invoked via ``python -m seattleflu.db.cli``.
 """
-import click
-from typing import NoReturn
 
-
-# Invoked by bin/id3c
-@click.group(help = __doc__)
-def cli() -> NoReturn:
-    pass
-
-
-# Load all top-level seattleflu.db.cli.command packages, giving them an
-# opportunity to register their commands using @cli.command(…).
-from .command import *
-
-
-# Invoked via `python -m seattleflu.db.cli`.
 if __name__ == "__main__":
+    from seattleflu.db.cli import cli
     cli(prog_name = "id3c")

--- a/lib/seattleflu/db/cli/command/etl/__init__.py
+++ b/lib/seattleflu/db/cli/command/etl/__init__.py
@@ -2,7 +2,7 @@
 Run ETL routines
 """
 import click
-from seattleflu.db.cli.__main__ import cli
+from seattleflu.db.cli import cli
 
 
 @cli.group("etl", help = __doc__)

--- a/lib/seattleflu/db/cli/command/identifier.py
+++ b/lib/seattleflu/db/cli/command/identifier.py
@@ -25,7 +25,7 @@ import logging
 import seattleflu.db as db
 from seattleflu import labelmaker
 from seattleflu.db.session import DatabaseSession
-from seattleflu.db.cli.__main__ import cli
+from seattleflu.db.cli import cli
 
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
This makes for nicer command-line invocations, and also means it may be invoked from outside of the project repo.