### PR TITLE
Add NWGC sample ID to sample details

### DIFF
--- a/lib/seattleflu/db/cli/command/etl/presence_absence.py
+++ b/lib/seattleflu/db/cli/command/etl/presence_absence.py
@@ -34,7 +34,7 @@ LOG = logging.getLogger(__name__)
 # presence-absence tests lacking this revision number in their log.  If a 
 # change to the ETL routine necessitates re-processing all presence-absence tests, 
 # this revision number should be incremented.
-REVISION = 2
+REVISION = 3
 
 
 @etl.command("presence-absence", help = __doc__)
@@ -267,9 +267,11 @@ def sample_identifier(db: DatabaseSession, barcode: str) -> str:
 
 def sample_details(document: dict) -> dict:
     """
+    Capture NWGC sample ID.
     Capture details about the go/no-go sequencing call for this sample.
     """
     return {
+        "nwgc_id": document['sampleId'],
         "sequencing_call": {
             "comment": document['sampleComment'],
             "initial": document['initialProceedToSequencingCall'],


### PR DESCRIPTION
Update the presence-absence etl process to
grab the NWGC sample ID that comes with the
test results and add it to the sample details within
warehouse schema.

This will make pairing between NWGC sample ID
and SFS UUID much easier in the future for 
assembly work.