### PR TITLE
Encounter age

### DIFF
--- a/schema/deploy/functions/age_conversion.sql
+++ b/schema/deploy/functions/age_conversion.sql
@@ -1,0 +1,37 @@
+-- Deploy seattleflu/schema:functions/age_conversion to pg
+
+begin;
+
+create or replace function public.age_in_years(age interval) returns numeric
+    language sql as $$
+        -- Interval periods less than a full month are explicitly ignored.  We
+        -- don't expect to store them and don't expect to want to report them.
+        select round(
+              extract(years from $1)::int
+            + extract(months from $1)::int * 1::numeric / 12,
+            2
+        )
+    $$
+    returns null on null input
+    immutable
+    parallel safe;
+
+
+create or replace function public.age_in_months(age interval) returns integer
+    language sql as $$
+        -- Interval periods less than a full month are explicitly ignored.  We
+        -- don't expect to store them and don't expect to want to report them.
+        select extract(years from $1)::int * 12
+             + extract(months from $1)::int
+    $$
+    returns null on null input
+    immutable
+    parallel safe;
+
+comment on function public.age_in_years is 
+    'Converts age interval into numeric age in years';
+
+comment on function public.age_in_months is
+    'Converts age interval into integer age in months';
+
+commit;

--- a/schema/deploy/shipping/age-bin-v2.sql
+++ b/schema/deploy/shipping/age-bin-v2.sql
@@ -1,0 +1,65 @@
+-- Deploy seattleflu/schema:shipping/age-bin-v2 to pg
+-- requires: types/intervalrange
+
+begin;
+
+create table shipping.age_bin_fine_v2 (
+    range intervalrange primary key,
+
+    constraint age_only_in_one_fine_range_v2
+        exclude using gist (range with &&)
+);
+
+create index age_bin_fine_range_idx_v2 on shipping.age_bin_fine_v2 using gist(range);
+
+comment on table shipping.age_bin_fine_v2 is 
+    'Version 2 of fine-grained age bins that uses intervalrange type';
+comment on column shipping.age_bin_fine_v2.range is
+    'The range of each age bin defined as intervalrange';
+
+insert into shipping.age_bin_fine_v2 values
+    ('[0 mon,1 mon)'::intervalrange),
+    ('[1 mon,6 mons)'::intervalrange),
+    ('[6 mons,1 year)'::intervalrange),
+    ('[1 years,5 years)'::intervalrange),
+    ('[5 years,10 years)'::intervalrange),
+    ('[10 years,15 years)'::intervalrange),
+    ('[15 years,20 years)'::intervalrange),
+    ('[20 years,25 years)'::intervalrange),
+    ('[25 years,30 years)'::intervalrange),
+    ('[30 years,35 years)'::intervalrange),
+    ('[35 years,40 years)'::intervalrange),
+    ('[40 years,45 years)'::intervalrange),
+    ('[45 years,50 years)'::intervalrange),
+    ('[50 years,55 years)'::intervalrange),
+    ('[55 years,60 years)'::intervalrange),
+    ('[60 years,65 years)'::intervalrange),
+    ('[65 years,70 years)'::intervalrange),
+    ('[70 years,75 years)'::intervalrange),
+    ('[75 years,80 years)'::intervalrange),
+    ('[80 years,85 years)'::intervalrange),
+    ('[85 years,90 years)'::intervalrange),
+    ('[90 years,)'::intervalrange);
+
+create table shipping.age_bin_coarse_v2 (
+    range intervalrange primary key,
+
+    constraint age_only_in_one_coarse_range_v2
+        exclude using gist (range with &&)
+);
+
+create index age_bin_coarse_range_idx_v2 on shipping.age_bin_coarse_v2 using gist(range);
+
+comment on table shipping.age_bin_coarse_v2 is
+    'Version 2 of coarse-grained age bins that uses intervalrange type';
+comment on column shipping.age_bin_coarse_v2.range is
+    'The range of each age bin defined as intervalrange';
+
+insert into shipping.age_bin_coarse_v2 values
+    ('[0 mon,6 mons)'::intervalrange),
+    ('[6 mons, 5 years)'::intervalrange),
+    ('[5 years,18 years)'::intervalrange),
+    ('[18 years,65 years)'::intervalrange),
+    ('[65 years,)'::intervalrange);
+
+commit;

--- a/schema/deploy/shipping/views.sql
+++ b/schema/deploy/shipping/views.sql
@@ -138,6 +138,7 @@ create view shipping.incidence_model_observation_v2 as
            (encountered at time zone 'US/Pacific')::date as encountered_date,
            to_char((encountered at time zone 'US/Pacific')::date, 'IYYY-"W"IW') as encountered_week,
 
+           site.identifier as site,
            site.details->>'type' as site_type,
 
            individual.identifier as individual,

--- a/schema/deploy/shipping/views@2019-06-03-age-column.sql
+++ b/schema/deploy/shipping/views@2019-06-03-age-column.sql
@@ -14,7 +14,10 @@ begin;
 -- there needs to be a lag between view development and consumers being
 -- updated, copy the view definition into v2 and make changes there.
 
-create or replace view shipping.incidence_model_observation_v1 as
+drop view shipping.incidence_model_observation_v1;
+drop view shipping.presence_absence_result_v1;
+
+create view shipping.incidence_model_observation_v1 as
 
     select encounter.identifier as encounter,
 
@@ -113,7 +116,7 @@ grant select
    on shipping.incidence_model_observation_v1
    to "incidence-modeler";
 
-create or replace view shipping.presence_absence_result_v1 as
+create view shipping.presence_absence_result_v1 as
 
     select sample.identifier as sample,
            target.identifier as target,

--- a/schema/deploy/types/intervalrange.sql
+++ b/schema/deploy/types/intervalrange.sql
@@ -1,0 +1,25 @@
+-- Deploy seattleflu/schema:types/intervalrange to pg
+
+begin;
+
+create function public.interval_subtype_diff(x interval, y interval)
+    returns float8
+    returns null on null input
+    language sql as $$
+        select extract(epoch from (x - y))
+    $$
+    immutable
+    parallel safe;
+
+create type public.intervalrange as range (
+    subtype = interval,
+    subtype_diff = interval_subtype_diff
+);
+
+comment on function public.interval_subtype_diff is
+    'Calculates the difference between two time intervals (durations)';
+
+comment on type public.intervalrange is 
+    'Range of time intervals (durations)';
+
+commit;

--- a/schema/deploy/warehouse/encounter/age.sql
+++ b/schema/deploy/warehouse/encounter/age.sql
@@ -1,0 +1,14 @@
+-- Deploy seattleflu/schema:warehouse/encounter/age to pg
+-- requires: warehouse/encounter
+
+begin;
+
+alter table warehouse.encounter
+    add column age interval
+    constraint encounter_age_only_precise_to_months 
+        check(date_trunc('month', age) = age);
+
+comment on column warehouse.encounter.age is
+    'Age of individual at the time of encounter';
+
+commit;

--- a/schema/revert/functions/age_conversion.sql
+++ b/schema/revert/functions/age_conversion.sql
@@ -1,0 +1,8 @@
+-- Revert seattleflu/schema:functions/age_conversion from pg
+
+begin;
+
+drop function public.age_in_years(interval);
+drop function public.age_in_months(interval);
+
+commit;

--- a/schema/revert/shipping/age-bin-v2.sql
+++ b/schema/revert/shipping/age-bin-v2.sql
@@ -1,0 +1,8 @@
+-- Revert seattleflu/schema:shipping/age-bin-v2 from pg
+
+begin;
+
+drop table shipping.age_bin_fine_v2;
+drop table shipping.age_bin_coarse_v2;
+
+commit;

--- a/schema/revert/shipping/views.sql
+++ b/schema/revert/shipping/views.sql
@@ -14,6 +14,8 @@ begin;
 -- there needs to be a lag between view development and consumers being
 -- updated, copy the view definition into v2 and make changes there.
 
+drop view shipping.incidence_model_observation_v2;
+
 create or replace view shipping.incidence_model_observation_v1 as
 
     select encounter.identifier as encounter,

--- a/schema/revert/shipping/views@2019-06-03-age-column.sql
+++ b/schema/revert/shipping/views@2019-06-03-age-column.sql
@@ -14,7 +14,9 @@ begin;
 -- there needs to be a lag between view development and consumers being
 -- updated, copy the view definition into v2 and make changes there.
 
-create or replace view shipping.incidence_model_observation_v1 as
+drop view shipping.incidence_model_observation_v1;
+
+create view shipping.incidence_model_observation_v1 as
 
     select encounter.identifier as encounter,
 
@@ -113,26 +115,6 @@ grant select
    on shipping.incidence_model_observation_v1
    to "incidence-modeler";
 
-create or replace view shipping.presence_absence_result_v1 as
+drop view shipping.presence_absence_result_v1;
 
-    select sample.identifier as sample,
-           target.identifier as target,
-           present
-
-    from warehouse.sample
-    join warehouse.presence_absence using (sample_id)
-    join warehouse.target using (target_id)
-    where target.control = false;
-
-comment on view shipping.presence_absence_result_v1 is
-    'View of warehoused presence-absence results for modeling and viz teams';
-
-revoke all
-    on shipping.presence_absence_result_v1
-  from "incidence-modeler";
-  
-grant select
-    on shipping.presence_absence_result_v1
-    to "incidence-modeler";
-    
 commit;

--- a/schema/revert/types/intervalrange.sql
+++ b/schema/revert/types/intervalrange.sql
@@ -1,0 +1,8 @@
+-- Revert seattleflu/schema:types/intervalrange from pg
+
+begin;
+
+drop type public.intervalrange;
+drop function public.interval_subtype_diff(interval, interval);
+
+commit;

--- a/schema/revert/warehouse/encounter/age.sql
+++ b/schema/revert/warehouse/encounter/age.sql
@@ -1,0 +1,8 @@
+-- Revert seattleflu/schema:warehouse/encounter/age from pg
+
+begin;
+
+alter table warehouse.encounter
+    drop column age;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -74,3 +74,4 @@ roles/identifier-minter/grants [warehouse/identifier roles/identifier-minter/cre
 warehouse/identifier/triggers/barcode-distance-check [warehouse/identifier/triggers/barcode-distance-check@2019-05-31-identifier-minter warehouse/identifier functions/hamming_distance] 2019-05-31T17:41:38Z Kairsten Fay <kfay@fredhutch.org> # Mark the trigger function
 warehouse/encounter/age [warehouse/encounter] 2019-05-30T23:09:41Z Jover Lee <joverlee@fredhutch.org> # Add age column to encounter
 functions/age_conversion 2019-05-31T20:57:07Z Jover Lee <joverlee@fredhutch.org> # Age conversion functions to change age interval to numeric age
+types/intervalrange 2019-06-03T16:03:03Z Jover Lee <joverlee@fredhutch.org> # Create type intervalrange

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -72,3 +72,4 @@ roles/identifier-minter/create 2019-05-29T00:35:13Z Kairsten Fay <kfay@fredhutch
 roles/identifier-minter/grants [warehouse/identifier roles/identifier-minter/create] 2019-05-29T00:48:29Z Kairsten Fay <kfay@fredhutch.org> # Grants to identifier-minter
 @2019-05-31-identifier-minter 2019-05-31T17:39:34Z Kairsten Fay <kfay@fredhutch.org> # Mark `warehouse.identifier_barcode_distance_check()` with security definer.\n\nThis rework is necessary for creating the "identifier-minter" role.
 warehouse/identifier/triggers/barcode-distance-check [warehouse/identifier/triggers/barcode-distance-check@2019-05-31-identifier-minter warehouse/identifier functions/hamming_distance] 2019-05-31T17:41:38Z Kairsten Fay <kfay@fredhutch.org> # Mark the trigger function
+warehouse/encounter/age [warehouse/encounter] 2019-05-30T23:09:41Z Jover Lee <joverlee@fredhutch.org> # Add age column to encounter

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -76,3 +76,5 @@ warehouse/encounter/age [warehouse/encounter] 2019-05-30T23:09:41Z Jover Lee <jo
 functions/age_conversion 2019-05-31T20:57:07Z Jover Lee <joverlee@fredhutch.org> # Age conversion functions to change age interval to numeric age
 types/intervalrange 2019-06-03T16:03:03Z Jover Lee <joverlee@fredhutch.org> # Create type intervalrange
 shipping/age-bin-v2 [types/intervalrange] 2019-06-03T16:20:43Z Jover Lee <joverlee@fredhutch.org> # Version 2 age bin tables that use intervalrange type
+@2019-06-03-age-column 2019-06-03T19:34:42Z Jover Lee <joverlee@fredhutch.org> # Schema as of 03 June 2019
+shipping/views [shipping/views@2019-06-03-age-column shipping/age-bin-v2] 2019-06-03T19:36:12Z Jover Lee <joverlee@fredhutch.org> # Update modeling views to include new age column and age bin tables

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -75,3 +75,4 @@ warehouse/identifier/triggers/barcode-distance-check [warehouse/identifier/trigg
 warehouse/encounter/age [warehouse/encounter] 2019-05-30T23:09:41Z Jover Lee <joverlee@fredhutch.org> # Add age column to encounter
 functions/age_conversion 2019-05-31T20:57:07Z Jover Lee <joverlee@fredhutch.org> # Age conversion functions to change age interval to numeric age
 types/intervalrange 2019-06-03T16:03:03Z Jover Lee <joverlee@fredhutch.org> # Create type intervalrange
+shipping/age-bin-v2 [types/intervalrange] 2019-06-03T16:20:43Z Jover Lee <joverlee@fredhutch.org> # Version 2 age bin tables that use intervalrange type

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -73,3 +73,4 @@ roles/identifier-minter/grants [warehouse/identifier roles/identifier-minter/cre
 @2019-05-31-identifier-minter 2019-05-31T17:39:34Z Kairsten Fay <kfay@fredhutch.org> # Mark `warehouse.identifier_barcode_distance_check()` with security definer.\n\nThis rework is necessary for creating the "identifier-minter" role.
 warehouse/identifier/triggers/barcode-distance-check [warehouse/identifier/triggers/barcode-distance-check@2019-05-31-identifier-minter warehouse/identifier functions/hamming_distance] 2019-05-31T17:41:38Z Kairsten Fay <kfay@fredhutch.org> # Mark the trigger function
 warehouse/encounter/age [warehouse/encounter] 2019-05-30T23:09:41Z Jover Lee <joverlee@fredhutch.org> # Add age column to encounter
+functions/age_conversion 2019-05-31T20:57:07Z Jover Lee <joverlee@fredhutch.org> # Age conversion functions to change age interval to numeric age

--- a/schema/verify/functions/age_conversion.sql
+++ b/schema/verify/functions/age_conversion.sql
@@ -1,0 +1,38 @@
+-- Verify seattleflu/schema:functions/age_conversion on pg
+
+begin;
+
+do $$ 
+	declare
+    	age record;
+	begin
+		create temporary table ages (age_as_interval, age_in_months, age_in_years) as values
+			('0 mon'::interval, 0::int, 0::numeric),
+			('1 mon', 1, 0.08),
+			('2 mons', 2, 0.17),
+			('3 mons', 3, 0.25),
+			('4 mons', 4, 0.33),
+			('5 mons', 5, 0.42),
+			('6 mons', 6, 0.5),
+			('7 mons', 7, 0.58),
+			('8 mons', 8, 0.67),
+			('9 mons', 9, 0.75),
+			('10 mons', 10, 0.83),
+			('11 mons', 11, 0.92),
+			('1 year', 12, 1),
+			('2 years', 24, 2),
+			('3 years', 36, 3), 
+			('4 years', 48, 4), 
+			('5 years', 60, 5),
+			('6 years', 72, 6);
+
+		for age in select ages.age_in_months, ages.age_in_years, age_in_months(age_as_interval) as months, age_in_years(age_as_interval) as years
+		  from ages loop
+  
+  			assert age.age_in_months = age.months;
+			assert age.age_in_years = age.years;
+		end loop;
+
+end $$;
+
+rollback;

--- a/schema/verify/shipping/age-bin-v2.sql
+++ b/schema/verify/shipping/age-bin-v2.sql
@@ -1,0 +1,8 @@
+-- Verify seattleflu/schema:shipping/age-bin-v2 on pg
+
+begin;
+
+select pg_catalog.has_table_privilege('shipping.age_bin_fine_v2', 'select');
+select pg_catalog.has_table_privilege('shipping.age_bin_coarse_v2', 'select');
+
+rollback;

--- a/schema/verify/shipping/views.sql
+++ b/schema/verify/shipping/views.sql
@@ -12,4 +12,9 @@ select 1/(count(*) = 1)::int
  where array[table_schema, table_name]::text[]
      = pg_catalog.parse_ident('shipping.presence_absence_result_v1');
 
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v2');
+
 rollback;

--- a/schema/verify/shipping/views@2019-06-03-age-column.sql
+++ b/schema/verify/shipping/views@2019-06-03-age-column.sql
@@ -1,0 +1,15 @@
+-- Verify seattleflu/schema:shipping/views on pg
+
+begin;
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.incidence_model_observation_v1');
+
+select 1/(count(*) = 1)::int
+  from information_schema.views
+ where array[table_schema, table_name]::text[]
+     = pg_catalog.parse_ident('shipping.presence_absence_result_v1');
+
+rollback;

--- a/schema/verify/types/intervalrange.sql
+++ b/schema/verify/types/intervalrange.sql
@@ -1,0 +1,29 @@
+-- Verify seattleflu/schema:types/intervalrange on pg
+
+begin;
+
+select 1/(count(*) = 1)::int
+    from pg_type
+    where typname = 'intervalrange';
+
+do $$
+declare
+    bin record;
+begin
+    create temporary table bins (age_range) as values
+         ('(,1 month)'::intervalrange)
+        ,('[1 month,6 months)'::intervalrange)
+        ,('[6 months,1 year)'::intervalrange)
+        ,('[1 year,2 years)'::intervalrange)
+        ,('[2 years,4 years)'::intervalrange)
+        ,('[4 years,)'::intervalrange)
+    ;
+
+    -- Sanity check that range adjacency works
+    for bin in select age_range -|- lead(age_range) over (order by age_range) as adjacent from bins limit 5 loop
+        assert bin.adjacent;
+    end loop;
+end
+$$;
+
+rollback;

--- a/schema/verify/warehouse/encounter/age.sql
+++ b/schema/verify/warehouse/encounter/age.sql
@@ -1,0 +1,29 @@
+-- Verify seattleflu/schema:warehouse/encounter/age on pg
+
+begin;
+
+do $$ begin
+    -- Insert encounters with various ages
+    with
+    site as (
+        insert into warehouse.site (identifier) values ('__SITE__')
+        returning site_id as id
+    ),
+    individual as (
+        insert into warehouse.individual (identifier) values ('__INDIVIDUAL__')
+        returning individual_id as id
+    )
+    insert into warehouse.encounter (identifier, individual_id, site_id, encountered, age)
+        values('__ENCOUNTER_1__', (select id from individual), (select id from site), now(), '1 year 2 months'),
+              ('__ENCOUNTER_2__', (select id from individual), (select id from site), now(), '1 month'),
+              ('__ENCOUNTER_3__', (select id from individual), (select id from site), now(), null);
+
+    -- Assert extractions of intervals work as expected
+    assert (select extract(year from age) from warehouse.encounter where identifier = '__ENCOUNTER_1__') = 1;
+    assert (select extract(month from age) from warehouse.encounter where identifier = '__ENCOUNTER_1__') = 2;
+    assert (select extract(year from age) from warehouse.encounter where identifier ='__ENCOUNTER_2__') = 0;
+    assert (select extract(month from age) from warehouse.encounter where identifier ='__ENCOUNTER_2__') = 1;
+
+end $$;
+
+rollback;


### PR DESCRIPTION
This PR pulls age out of the encounter details into a column for the encounter table. 

After much discussion with @tsibley, we decided that the best data type for the age column is [intervals](https://www.postgresql.org/docs/11/datatype-datetime.html#DATATYPE-INTERVAL-INPUT), since it is much more human-readable than large numbers in months or age in floats. 

Public functions are created to convert the intervals to numeric values in both months and years. These are used in the modeling views since the modeling teams have a preference for numeric types. 