### PR TITLE
Move existing api underneath /v1/receiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Data logistics for the [Seattle Flu Study](https://seattleflu.org) and
 [Flu@Home](https://fluathome.org), enabling real-time genomic epidemiology
 studies.
 
+## Navigation
+* [Database](#database)
+* [Web API](#web-api)
+* [CLI](#cli)
+* [Setup](#setup)
+
 ## Database
 
 [PostgreSQL 10](https://www.postgresql.org/about/news/1786/)
@@ -80,7 +86,7 @@ General principles to follow when developing the schema.
 * Do the ~simplest thing that meets our immediate needs.  Aim for ease of
   modification in the future rather than trying to guess future needs in
   advance.
-  
+
   It can be really hard to stick to this principle, but it turns out that the
   best way to make something flexible for future needs is to make it as simple
   as possible now so it can be modified later.
@@ -114,7 +120,7 @@ For example:
 * Nouns (tables, columns, etc) in our system should consider adopting the
   equivalent terms used by [FHIR R4](http://www.hl7.org/implement/standards/fhir/)
   resources.
-  
+
   This will aid with producing FHIR documents in the future and provides a
   consistent terminology on which to discuss concepts more broadly than our
   group.  FHIR is a large specification and there is a lot to digest; it's
@@ -178,8 +184,9 @@ Python 3 + [Flask](http://flask.pocoo.org)
 
 * Database connection details are set entirely using the [standard libpq
   environment variables](https://www.postgresql.org/docs/current/libpq-envars.html),
-  such as `PGHOST` and `PGDATABASE`.
-  
+  such as `PGHOST` and `PGDATABASE`. You may provide these when starting the
+  API server.
+
   User authentication is performed against the database for each request, so
   you do not (and should not) provide a username and password when starting the
   API server.
@@ -193,11 +200,30 @@ Python 3 + [Flask](http://flask.pocoo.org)
 ### Starting the server
 
 The commands `pipenv run python -m seattleflu.api` or `pipenv run flask run`
-will run the application's __development__ server.
+will run the application's __development__ server. To provide database
+connection details while starting the development server, run the command
+`PGDATABASE=DB_NAME pipenv run flask run`, substituting `DB_NAME` with the name
+of your database.
 
 For production, a standard `api.wsgi` file is provided which can be used by any
 web server with WSGI support.
 
+### Examples
+
+User authentication must be provided when making POST requests to the API. For
+example, you can run the following `curl` command to send JSON data named
+`enrollments.json` to the `/enrollment` endpoint on a local development server:
+
+```sh
+curl http://localhost:5000/enrollment \
+  --header "Content-Type: application/json" \
+  --data-binary @enrollments.json \
+  --user USERNAME
+```
+
+Substitute your own local database username for `USERNAME`.  This will prompt
+you for a password; you can also specify it directly by using `--user
+"USERNAME:PASSWORD"`, though be aware it will be saved to your shell history.
 
 ## CLI
 

--- a/lib/seattleflu/api/routes.py
+++ b/lib/seattleflu/api/routes.py
@@ -9,14 +9,17 @@ from .utils.routes import authenticated_datastore_session_required, content_type
 
 LOG = logging.getLogger(__name__)
 
-api = Blueprint("api", __name__)
+api_v1 = Blueprint('api_v1', 'api_v1', url_prefix='/v1')
+api_unversioned = Blueprint('api_unversioned', 'api_unversioned', url_prefix='/')
 
 blueprints = [
-    api,
+    api_v1,
+    api_unversioned,
 ]
 
 
-@api.route("/", methods = ['GET'])
+@api_v1.route("/", methods = ['GET'])
+@api_unversioned.route("/", methods = ['GET'])
 def index():
     """
     Show an index page with documentation.
@@ -24,7 +27,8 @@ def index():
     return send_file("static/index.html", "text/html; charset=UTF-8")
 
 
-@api.route("/enrollment", methods = ['POST'])
+@api_v1.route("/receiving/enrollment", methods = ['POST'])
+@api_unversioned.route("/enrollment", methods = ['POST'])
 @content_types_accepted(["application/json"])
 @check_content_length
 @authenticated_datastore_session_required
@@ -45,7 +49,8 @@ def receive_enrollment(*, session):
     return "", 204
 
 
-@api.route("/presence-absence", methods = ['POST'])
+@api_v1.route("/receiving/presence-absence", methods = ['POST'])
+@api_unversioned.route("/presence-absence", methods = ['POST'])
 @content_types_accepted(["application/json"])
 @check_content_length
 @authenticated_datastore_session_required
@@ -64,7 +69,8 @@ def receive_presence_absence(*, session):
     return "", 204
 
 
-@api.route("/sequence-read-set", methods = ['POST'])
+@api_v1.route("/receiving/sequence-read-set", methods = ['POST'])
+@api_unversioned.route("/sequence-read-set", methods = ['POST'])
 @content_types_accepted(["application/json"])
 @check_content_length
 @authenticated_datastore_session_required

--- a/lib/seattleflu/api/static/index.html
+++ b/lib/seattleflu/api/static/index.html
@@ -42,31 +42,7 @@
 
     <h3 class="code">POST /v1/receiving/presence-absence</h3>
     <p>Stores the request data as presence/absence calls in a receiving area of
-    the study database.
-
-    <p>By convention, the body of the request should be a JSON object like the
-    following:
-
-<pre>{
-  "calls": [
-    {
-      "source": {
-        "sample": "20e1d4a2",
-        "rack": "TS01143828",
-        "tube": "1183001056",
-        "well": "A:1",
-        ...
-      },
-      "target": {
-        "name": "RSVA",
-        "control": false,
-        ...
-      },
-      "present": true
-    },
-    ...
-  ]
-}</pre>
+    the study database. Accepts any JSON object.
 
     <h3 class="code">POST /v1/receiving/sequence-read-set</h3>
     <p>Stores the request data as a sequence read set document in a receiving
@@ -98,31 +74,7 @@
 
     <h3 class="code">POST /presence-absence</h3>
     <p>Stores the request data as presence/absence calls in a receiving area of
-    the study database.
-
-    <p>By convention, the body of the request should be a JSON object like the
-    following:
-
-<pre>{
-  "calls": [
-    {
-      "source": {
-        "sample": "20e1d4a2",
-        "rack": "TS01143828",
-        "tube": "1183001056",
-        "well": "A:1",
-        ...
-      },
-      "target": {
-        "name": "RSVA",
-        "control": false,
-        ...
-      },
-      "present": true
-    },
-    ...
-  ]
-}</pre>
+    the study database. Accepts any JSON object.
 
     <h3 class="code">POST /sequence-read-set</h3>
     <p>Stores the request data as a sequence read set document in a receiving

--- a/lib/seattleflu/api/static/index.html
+++ b/lib/seattleflu/api/static/index.html
@@ -36,9 +36,65 @@
 
     <h2>Routes</h2>
 
+    <h3 class="code">POST /v1/receiving/enrollment</h3>
+    <p>Stores the request data as an enrollment document in a receiving area of
+    the study database. Accepts any JSON object.
+
+    <h3 class="code">POST /v1/receiving/presence-absence</h3>
+    <p>Stores the request data as presence/absence calls in a receiving area of
+    the study database.
+
+    <p>By convention, the body of the request should be a JSON object like the
+    following:
+
+<pre>{
+  "calls": [
+    {
+      "source": {
+        "sample": "20e1d4a2",
+        "rack": "TS01143828",
+        "tube": "1183001056",
+        "well": "A:1",
+        ...
+      },
+      "target": {
+        "name": "RSVA",
+        "control": false,
+        ...
+      },
+      "present": true
+    },
+    ...
+  ]
+}</pre>
+
+    <h3 class="code">POST /v1/receiving/sequence-read-set</h3>
+    <p>Stores the request data as a sequence read set document in a receiving
+    area of the study database.
+
+    <p>By convention, the body of the request should be a JSON object like the
+    following:
+
+<pre>{
+  "source": {
+    "sample": "20e1d4a2",
+    ...
+  },
+  "reads": [
+    "https://server/path/to/reads_L001_R1_001.fastq.gz",
+    "https://server/path/to/reads_L001_R2_001.fastq.gz",
+    ...
+  ]
+}</pre>
+
+    <h2>Legacy Routes</h2>
+    <p>
+      These routes have been deprecated but continue to be supported (for now).
+    </p>
+
     <h3 class="code">POST /enrollment</h3>
     <p>Stores the request data as an enrollment document in a receiving area of
-    the study database.
+    the study database. Accepts any JSON object.
 
     <h3 class="code">POST /presence-absence</h3>
     <p>Stores the request data as presence/absence calls in a receiving area of


### PR DESCRIPTION
From Trello:

> This provides better versioning and namespacing for growth and also means we can share nouns for resource endpoints between the receiving area and warehouse area, e.g.:
> 
> ```
> /v1/receiving/presence-absence
> /v1/warehouse/presence-absence
> ```
> 
> Support old endpoints as deprecated aliases for now, then work on getting consumers of the API moved over.