### PR TITLE
clinical/manifest upload: Copy NDJSON stream instead of inserting individually

### DIFF
--- a/lib/seattleflu/db/cli/command/clinical.py
+++ b/lib/seattleflu/db/cli/command/clinical.py
@@ -323,16 +323,11 @@ def upload(clinical_file):
     db = DatabaseSession()
 
     try:
-        for document in (line.strip() for line in clinical_file):
-            LOG.debug(f"Processing clinical record: {document}")
+        LOG.info(f"Copying clinical records from {clinical_file.name}")
 
-            clinical = db.fetch_row("""
-                insert into receiving.clinical (document) values (%s)
-                    returning clinical_id as id
-                """, (document,))
+        row_count = db.copy_from_ndjson(("receiving", "clinical", "document"), clinical_file)
 
-            LOG.info(f"Created received clinical record {clinical.id}")
-
+        LOG.info(f"Received {row_count:,} clinical records")
         LOG.info("Committing all changes")
         db.commit()
 

--- a/lib/seattleflu/db/cli/command/manifest.py
+++ b/lib/seattleflu/db/cli/command/manifest.py
@@ -338,16 +338,11 @@ def upload(manifest_file):
     db = DatabaseSession()
 
     try:
-        for document in (line.strip() for line in manifest_file):
-            LOG.debug(f"Processing sample manifest record: {document}")
+        LOG.info(f"Copying sample manifest records from {manifest_file.name}")
 
-            manifest = db.fetch_row("""
-               insert into receiving.manifest (document) values (%s)
-                   returning manifest_id as id
-               """, (document,))
+        row_count = db.copy_from_ndjson(("receiving", "manifest", "document"), manifest_file)
 
-            LOG.info(f"Created received manifest record {manifest.id}")
-
+        LOG.info(f"Received {row_count:,} manifest records")
         LOG.info("Committing all changes")
         db.commit()
 


### PR DESCRIPTION
Improves transaction time by a couple orders of magnitude, from hours to
1-2 seconds.

The little bit of escaping awkwardness is encapsulated into a
DatabaseSession method to keep it nicely contained.