### PR TITLE
clinical parse-uw: Account for column name change in HMC manifest

### DIFF
--- a/lib/seattleflu/db/cli/command/clinical.py
+++ b/lib/seattleflu/db/cli/command/clinical.py
@@ -131,6 +131,7 @@ def load_data(uw_filename: str, uw_nwh_file: str, hmc_sch_file: str):
                                     'Collection Date (per tube)': 'Collection date'})
 
     hmc_manifest = load_manifest_data(hmc_sch_file, 'HMC')
+    hmc_manifest = hmc_manifest.rename(columns={'Barcode ID (Sample ID)': 'Barcode ID'})
 
     return clinical_records, uw_manifest, nwh_manifest, hmc_manifest
 


### PR DESCRIPTION
This was accounted for in our separate manifest parsing, but not in the
different parsing of the manifest here.  The effect was that ~2,600 records
were skipped due to missing barcodes when reloading the clinical data
earlier today.

In the (hopefully near) future, we won't need to do the merge here and
this code will be deleted.