### PR TITLE
etl: move `SampleNotFoundError` to shared module

### DIFF
--- a/lib/seattleflu/db/cli/command/etl/__init__.py
+++ b/lib/seattleflu/db/cli/command/etl/__init__.py
@@ -243,6 +243,13 @@ def find_sample(db: DatabaseSession, identifier: str) -> Any:
     return sample
 
 
+class SampleNotFoundError(ValueError):
+    """
+    Raised when a function is unable to find an existing sample with the given
+    identifier.
+    """
+    pass
+
 class UnknownSiteError(ValueError):
     """
     Raised by :function:`site_identifier` if its provided *site_nickname*

--- a/lib/seattleflu/db/cli/command/etl/clinical.py
+++ b/lib/seattleflu/db/cli/command/etl/clinical.py
@@ -18,12 +18,12 @@ from . import (
     upsert_encounter,
     upsert_individual,
 
+    SampleNotFoundError,
     UnknownEthnicGroupError,
     UnknownFluShotResponseError,
     UnknownRaceError,
     UnknownSiteError,
 )
-from .presence_absence import SampleNotFoundError
 
 
 LOG = logging.getLogger(__name__)

--- a/lib/seattleflu/db/cli/command/etl/longitudinal.py
+++ b/lib/seattleflu/db/cli/command/etl/longitudinal.py
@@ -18,12 +18,12 @@ from . import (
     update_sample,
     upsert_encounter,
 
+    SampleNotFoundError,
     UnknownEthnicGroupError,
     UnknownFluShotResponseError,
     UnknownRaceError,
     UnknownSiteError,
 )
-from .presence_absence import SampleNotFoundError
 
 
 LOG = logging.getLogger(__name__)

--- a/lib/seattleflu/db/cli/command/etl/presence_absence.py
+++ b/lib/seattleflu/db/cli/command/etl/presence_absence.py
@@ -22,7 +22,7 @@ from typing import Any
 from seattleflu.db import find_identifier
 from seattleflu.db.session import DatabaseSession
 from seattleflu.db.datatypes import Json
-from . import etl
+from . import etl, SampleNotFoundError
 
 
 LOG = logging.getLogger(__name__)
@@ -373,12 +373,6 @@ def mark_processed(db, group_id: int) -> None:
              where presence_absence_id = %(group_id)s
             """, data)
 
-class SampleNotFoundError(ValueError):
-    """
-    Raised when :func:``update_sample`` is unable to find an existing
-    sample with the given identifier.
-    """
-    pass
 
 class UnknownControlStatusError(ValueError):
     """


### PR DESCRIPTION
Move the `SampleNotFoundError` from the `presence_absence` ETL routine
to a shared module. The `clinical` and `longitudinal` ETL routines were
previously importing it from `presence_absence`; this new, shared
location is more sensible.