### PR TITLE
Create kit processor role for automation

### DIFF
--- a/schema/deploy/roles/kit-processor/create.sql
+++ b/schema/deploy/roles/kit-processor/create.sql
@@ -1,0 +1,9 @@
+-- Deploy seattleflu/schema:roles/kit-processor/create to pg
+
+begin;
+
+create role "kit-processor";
+
+comment on role "kit-processor" is 'For kit ETL routines';
+
+commit;

--- a/schema/deploy/roles/kit-processor/grants.sql
+++ b/schema/deploy/roles/kit-processor/grants.sql
@@ -1,0 +1,45 @@
+-- Deploy seattleflu/schema:roles/kit-processor/grants to pg
+-- requires: roles/kit-processor/create
+-- requires: warehouse/kit
+-- requires: receiving/manifest
+-- requires: receiving/enrollment/processing-log
+-- requires: warehouse/identifier
+
+begin;
+
+-- This change is designed to be sqitch rework-able to make it easier to update
+-- the grants for this role.
+
+grant connect on database :"DBNAME" to "kit-processor";
+
+grant usage
+    on schema receiving, warehouse
+    to "kit-processor";
+
+grant select
+    on receiving.enrollment,
+       receiving.manifest
+    to "kit-processor";
+
+grant update (processing_log)
+    on receiving.enrollment,
+       receiving.manifest
+    to "kit-processor";
+
+grant select
+    on warehouse.identifier,
+       warehouse.identifier_set,
+       warehouse.encounter,
+       warehouse.site,
+       warehouse.sample
+    to "kit-processor";
+
+grant update (encounter_id)
+    on warehouse.sample
+    to "kit-processor";
+
+grant select, insert, update
+    on warehouse.kit
+    to "kit-processor";
+
+commit;

--- a/schema/revert/roles/kit-processor/create.sql
+++ b/schema/revert/roles/kit-processor/create.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:roles/kit-processor/create from pg
+
+begin;
+
+drop role "kit-processor";
+
+commit;

--- a/schema/revert/roles/kit-processor/grants.sql
+++ b/schema/revert/roles/kit-processor/grants.sql
@@ -1,0 +1,37 @@
+-- Revert seattleflu/schema:roles/kit-processor/grants from pg
+
+begin;
+
+revoke select, insert, update
+    on warehouse.kit
+    from "kit-processor";
+
+revoke update (encounter_id)
+    on warehouse.sample
+    from "kit-processor";
+
+revoke select
+    on warehouse.identifier,
+       warehouse.identifier_set,
+       warehouse.encounter,
+       warehouse.site,
+       warehouse.sample
+    from "kit-processor";
+
+revoke update (processing_log)
+    on receiving.enrollment,
+       receiving.manifest
+    from "kit-processor";
+
+revoke select
+    on receiving.enrollment,
+       receiving.manifest
+    from "kit-processor";
+
+revoke usage
+    on schema receiving, warehouse
+    from "kit-processor";
+
+revoke connect on database :"DBNAME" from "kit-processor";
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -90,3 +90,5 @@ warehouse/target/organism [warehouse/target warehouse/organism] 2019-06-21T22:01
 shipping/views [shipping/views@2019-07-12] 2019-07-12T21:42:46Z Thomas Sibley <tsibley@fredhutch.org> # Correct handling of encounters with multiple samples
 warehouse/kit [warehouse/encounter warehouse/sample] 2019-06-10T16:09:32Z Jover Lee <joverlee@fredhutch.org> # Add self-test-kit table to warehouse
 receiving/longitudinal [receiving/schema] 2019-06-11T22:46:10Z Kairsten Fay <kfay@fredhutch.org> # Receiving table for longitudinal data
+roles/kit-processor/create 2019-07-17T17:50:04Z Jover Lee <joverlee@fredhutch.org> # Create kit-processor role
+roles/kit-processor/grants [roles/kit-processor/create warehouse/kit receiving/manifest receiving/enrollment/processing-log warehouse/identifier] 2019-07-17T18:03:52Z Jover Lee <joverlee@fredhutch.org> # Grants to kit-processor

--- a/schema/verify/roles/kit-processor/create.sql
+++ b/schema/verify/roles/kit-processor/create.sql
@@ -1,0 +1,8 @@
+-- Verify seattleflu/schema:roles/kit-processor/create on pg
+
+begin;
+
+-- No real need to test that the user was created; the database would have
+-- thrown an error if it wasn't.
+
+rollback;

--- a/schema/verify/roles/kit-processor/grants.sql
+++ b/schema/verify/roles/kit-processor/grants.sql
@@ -1,0 +1,39 @@
+-- Verify seattleflu/schema:roles/kit-processor/grants on pg
+
+begin;
+
+select 1/pg_catalog.has_database_privilege('kit-processor', :'DBNAME', 'connect')::int;
+select 1/pg_catalog.has_schema_privilege('kit-processor', 'receiving', 'usage')::int;
+select 1/pg_catalog.has_schema_privilege('kit-processor', 'warehouse', 'usage')::int;
+select 1/pg_catalog.has_table_privilege('kit-processor', 'receiving.enrollment', 'select')::int;
+select 1/pg_catalog.has_table_privilege('kit-processor', 'receiving.manifest', 'select')::int;
+select 1/pg_catalog.has_column_privilege('kit-processor', 'receiving.enrollment', 'processing_log', 'update')::int;
+select 1/pg_catalog.has_column_privilege('kit-processor', 'receiving.manifest', 'processing_log', 'update')::int;
+select 1/pg_catalog.has_table_privilege('kit-processor', 'warehouse.identifier', 'select')::int;
+select 1/pg_catalog.has_table_privilege('kit-processor', 'warehouse.identifier_set', 'select')::int;
+select 1/pg_catalog.has_table_privilege('kit-processor', 'warehouse.encounter', 'select')::int;
+select 1/pg_catalog.has_table_privilege('kit-processor', 'warehouse.site', 'select')::int;
+select 1/pg_catalog.has_table_privilege('kit-processor', 'warehouse.sample', 'select')::int;
+select 1/pg_catalog.has_column_privilege('kit-processor', 'warehouse.sample','encounter_id', 'update')::int;
+select 1/pg_catalog.has_table_privilege('kit-processor', 'warehouse.kit', 'select, insert, update')::int;
+
+select 1/(not pg_catalog.has_table_privilege('kit-processor', 'receiving.enrollment', 'delete'))::int;
+select 1/(not pg_catalog.has_table_privilege('kit-processor', 'receiving.manifest', 'delete'))::int;
+select 1/(not pg_catalog.has_column_privilege('kit-processor', 'receiving.enrollment', 'enrollment_id', 'insert, update'))::int;
+select 1/(not pg_catalog.has_column_privilege('kit-processor', 'receiving.enrollment', 'document', 'insert, update'))::int;
+select 1/(not pg_catalog.has_column_privilege('kit-processor', 'receiving.enrollment', 'received', 'insert, update'))::int;
+select 1/(not pg_catalog.has_column_privilege('kit-processor', 'receiving.manifest', 'manifest_id', 'insert, update'))::int;
+select 1/(not pg_catalog.has_column_privilege('kit-processor', 'receiving.manifest', 'document', 'insert, update'))::int;
+select 1/(not pg_catalog.has_column_privilege('kit-processor', 'receiving.manifest', 'received', 'insert, update'))::int;
+select 1/(not pg_catalog.has_table_privilege('kit-processor', 'warehouse.identifier', 'insert, update, delete'))::int;
+select 1/(not pg_catalog.has_table_privilege('kit-processor', 'warehouse.identifier_set', 'insert, update, delete'))::int;
+select 1/(not pg_catalog.has_table_privilege('kit-processor', 'warehouse.encounter', 'insert, update, delete'))::int;
+select 1/(not pg_catalog.has_table_privilege('kit-processor', 'warehouse.site', 'insert, update, delete'))::int;
+select 1/(not pg_catalog.has_table_privilege('kit-processor', 'warehouse.sample', 'insert, delete'))::int;
+select 1/(not pg_catalog.has_column_privilege('kit-processor', 'warehouse.sample', 'sample_id', 'update'))::int;
+select 1/(not pg_catalog.has_column_privilege('kit-processor', 'warehouse.sample', 'identifier', 'update'))::int;
+select 1/(not pg_catalog.has_column_privilege('kit-processor', 'warehouse.sample', 'details', 'update'))::int;
+select 1/(not pg_catalog.has_column_privilege('kit-processor', 'warehouse.sample', 'collection_identifier', 'update'))::int;
+select 1/(not pg_catalog.has_table_privilege('kit-processor', 'warehouse.kit', 'delete'))::int;
+
+rollback;


### PR DESCRIPTION
Creates kit process role in the database via sqitch
to allow the automation of kit etl jobs. 

There was no need to create a `kit uploader` role
because the kit etl pulls data from `receiving.manifest` 
and `receiving.enrollment` which already have their
own uploaders.