### PR TITLE
Reportable notifications view

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Interact with the database on the command-line in your shell to:
 
 * Preprocess clinical data and upload it into receiving.
 
+* Send Slack notifications from the [Reportable Conditions Notifications Slack
+  App](https://api.slack.com/apps/ALJJAQGKH)
+
 The `bin/id3c` command is the entry point.  It must be run within the project
 environment, for example by using `pipenv run bin/id3c`.
 

--- a/lib/seattleflu/db/cli/command/__init__.py
+++ b/lib/seattleflu/db/cli/command/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "longitudinal",
     "sequence_read_set",
     "consensus_genome",
+    "reportable_conditions",
 ]
 
 

--- a/lib/seattleflu/db/cli/command/reportable_conditions.py
+++ b/lib/seattleflu/db/cli/command/reportable_conditions.py
@@ -1,0 +1,219 @@
+"""
+Run reportable condition notification routine.
+
+Sends a nicely formatted Slack message for samples with reportable conditions as
+described in the `warehouse.organism` table.
+
+Searches for unseen reportable conditions in `shipping.reportable_condition_v1`,
+and updates `warehouse.presence_absence` after sending a Slack alert.
+
+Visit the Reportable Conditions Notifications Slack app
+<https://api.slack.com/apps/ALJJAQGKH> to access the Slack Incoming Webhook
+URLs <https://api.slack.com/apps/ALJJAQGKH/incoming-webhooks?>. These URLs must
+be defined as environment variables outside of this command.
+
+\b
+Environment variables required:
+    * SLACK_WEBHOOK_REPORTING_GENERAL: incoming webhook URL for sending Slack
+        messages to the Seattle Flu Study #reporting-general channel
+    * SLACK_WEBHOOK_REPORTING_CHILDRENS: incoming webhook URL for sending Slack
+        messages to the Seattle Flu STudy #reporting-childrens channel
+"""
+import os
+import json
+import click
+import logging
+import requests
+from typing import List
+from textwrap import dedent
+from datetime import datetime, timezone
+from psycopg2.extras import NamedTupleCursor
+from seattleflu.db.cli import cli
+from seattleflu.db.session import DatabaseSession
+from seattleflu.db.datatypes import Json
+
+
+LOG = logging.getLogger(__name__)
+REVISION = 1
+
+
+@cli.group("reportable-conditions", help = __doc__)
+def reportable_conditions():
+    pass
+
+
+@reportable_conditions.command("notify")
+
+@click.option("--dry-run", "action",
+    help        = "Only go through the motions of changing the database (default)",
+    flag_value  = "rollback",
+    default     = True)
+
+@click.option("--prompt", "action",
+    help        = "Ask if changes to the database should be saved",
+    flag_value  = "prompt")
+
+@click.option("--commit", "action",
+    help        = "Save changes to the database",
+    flag_value  = "commit")
+
+def notify(*, action: str):
+    LOG.debug(f"Starting the reportable conditions notification routine, revision {REVISION}")
+
+    db = DatabaseSession()
+
+    def webhook(suffix):
+        return os.environ.get("SLACK_WEBHOOK_ALERTS_TEST") \
+            or os.environ[f"SLACK_WEBHOOK_REPORTING_{suffix}"]
+
+    SLACK_WEBHOOK_REPORTING_GENERAL = webhook("GENERAL")
+    SLACK_WEBHOOK_REPORTING_CHILDRENS = webhook("CHILDRENS")
+
+    childrens_sites = get_childrens_sites(db)
+
+    # Fetch and iterate over reportable condition records that aren't processed
+    #
+    # Rows we fetch are locked for update so that two instances of this
+    # command don't try to process the same reportable condition records.
+    LOG.debug("Fetching unprocessed reportable conditions records")
+
+    reportable_conditions = db.cursor("reportable_conditions")
+    reportable_conditions.execute("""
+        select reportable_condition_v1.*, presence_absence_id as id
+            from shipping.reportable_condition_v1
+            join warehouse.presence_absence using (presence_absence_id)
+        where (
+            not details ? 'reporting_status'
+              or
+            not details @> %s
+        )
+        order by id
+            for update of presence_absence;
+        """, (Json({ "revision": REVISION }),))
+
+    processed_without_error = None
+
+    try:
+        for record in reportable_conditions:
+            with db.savepoint(f"reportable condition presence_absence_id {record.id}"):
+                LOG.info(f"Processing reportable condition, presence_absence_id «{record.id}»")
+
+                url = SLACK_WEBHOOK_REPORTING_GENERAL \
+                    if record.site not in childrens_sites \
+                    else SLACK_WEBHOOK_REPORTING_CHILDRENS
+
+                response = send_slack_post_request(record, url)
+
+                if response.status_code == 200:
+                    mark_processed(db, record.id, {"reporting_status": "sent Slack notification"})
+                    LOG.info(f"Finished processing presence_absence_id «{record.id}»")
+
+                else:
+                    LOG.error(("Error: A Slack notification could not " \
+                    f"be sent for presence_absence_id «{record.id}».\n" \
+                    f"Slack API returned status code {response.status_code}: "\
+                    f"{response.text}"))
+
+    except Exception as error:
+        processed_without_error = False
+
+        LOG.error(f"Aborting with error")
+        raise error from None
+
+    else:
+        processed_without_error = True
+
+    finally:
+        if action == "prompt":
+            ask_to_commit = \
+                "Commit all changes?" if processed_without_error else \
+                "Commit successfully processed reportable condition records up to this point?"
+
+            commit = click.confirm(ask_to_commit)
+        else:
+            commit = action == "commit"
+
+        if commit:
+            LOG.info(
+                "Committing all changes" if processed_without_error else \
+                "Committing successfully processed reportable condition records up to this point")
+            db.commit()
+
+        else:
+            LOG.info("Rolling back all changes; the database will not be modified")
+            db.rollback()
+
+
+def get_childrens_sites(db) -> List:
+    """Gets all sites from the warehouse whose name contains 'Childrens'"""
+
+    childrens_sites = db.fetch_all("""
+        select identifier
+            from warehouse.site
+            where identifier like '%Childrens%'
+        """, )
+    return [site.identifier for site in childrens_sites]
+
+
+def send_slack_post_request(record: NamedTupleCursor.Record, url: str) -> requests.PreparedRequest:
+    """
+    Sends a POST request to a channel-specific Slack webhook *url*. The payload
+    of this POST request is composed using Slack blocks. These blocks provide
+    structure for a nicely formatted message that contains a link to
+    Metabase plus relevant information from the given *record* from the
+    database. The message contains, by request, a machine-friendly Json document
+    containing minimal sample details.
+    """
+    data = {
+        "sample": record.barcode,
+        "site": record.site,
+        "condition": record.lineage
+    }
+
+    payload = {
+        "text": f":rotating_light: {record.lineage} detected",
+        "blocks": [{
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": dedent(f"""
+                :rotating_light: @channel {record.lineage} detected. \n
+                *<https://backoffice.seattleflu.org/metabase/question/55|Go to Metabase>*
+                """)
+            }
+        },
+        {
+            "type": "section",
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Details:*\n```{json.dumps(data, sort_keys=True, indent=4)}```"
+                }
+            ]
+        }]
+    }
+
+    return requests.post(url, data=json.dumps(payload),
+                         headers={'Content-type': 'application/json'})
+
+
+def mark_processed(db, presence_absence_id: int, entry: {}) -> None:
+    LOG.debug(dedent(f"""
+    Marking reportable condition «{presence_absence_id}» as processed in the
+    presence_absence table"""))
+
+    data = {
+        "presence_absence_id": presence_absence_id,
+        "log_entry": Json({
+            **entry,
+            "revision": REVISION,
+            "timestamp": datetime.now(timezone.utc),
+        }),
+    }
+
+    with db.cursor() as cursor:
+        cursor.execute("""
+            update warehouse.presence_absence
+               set details = coalesce(details, '{}') || %(log_entry)s
+             where presence_absence_id = %(presence_absence_id)s
+            """, data)

--- a/lib/seattleflu/db/session.py
+++ b/lib/seattleflu/db/session.py
@@ -143,6 +143,16 @@ class DatabaseSession:
             return cursor.fetchone()
 
 
+    def fetch_all(self, sql: str, values: Union[Tuple, Mapping] = None) -> Any:
+        """
+        Fetches all rows from the results of the *sql* query. Useful for
+        writing alerts for new rows in queries of interest.
+        """
+        with self.cursor() as cursor:
+            cursor.execute(sql, values)
+            return cursor.fetchall()
+
+
     def copy_from_ndjson(self, qualified_column: Tuple, stream) -> int:
         """
         Copies JSON documents (one per line) from the file-like object *stream*


### PR DESCRIPTION
This is the VIEW version of https://trello.com/c/coA6Z3dR/11-reportable-condition-notifications. It includes seattleflu/id3c-customizations/pull/2. 

In this PR:
`warehouse.presence_absence` has a new `processing_log` column that is updated after a Slack 
notification.

`shipping.reportable_condition_v1` is a true view that reflects the Slack message status of reportable
conditions from `warehouse.presence_absence`. 
