### PR TITLE
db.session: Assert fetch_row() only finds one row

### DIFF
--- a/lib/seattleflu/db/session.py
+++ b/lib/seattleflu/db/session.py
@@ -139,6 +139,7 @@ class DatabaseSession:
         """
         with self.cursor() as cursor:
             cursor.execute(sql, values)
+            assert cursor.rowcount <= 1, f"More than one result row for fetch_row({sql!r}, {values!r})"
             return cursor.fetchone()
 
 


### PR DESCRIPTION
This is a typical sanity check since the query is expected to return at
most 1 row.  More rows indicate a likely programming error or unexpected
non-uniqueness condition.

I'm not sure why I forgot this check when I wrote the function in the
first place.  It's been a standard practice of mine for years.