### PR TITLE
Start of a new way to handle schema tags

### DIFF
--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -108,3 +108,4 @@ roles/consensus-genome-processor/grants [receiving/consensus-genome roles/consen
 receiving/redcap-det [receiving/schema] 2019-07-18T19:25:49Z Kairsten Fay <kfay@fredhutch.org> # Receiving table for REDCap DETs
 roles/redcap-det-uploader/create 2019-08-16T19:07:18Z Kairsten Fay <kfay@fredhutch.org> # Upload REDCap data entry trigger records into receiving
 roles/redcap-det-uploader/grants [receiving/redcap-det roles/redcap-det-uploader/create] 2019-08-16T19:20:57Z Kairsten Fay <kfay@fredhutch.org> # Grants to redcap-det-uploader
+@2019-08-22 2019-08-22T17:53:49Z Thomas Sibley <tsibley@fredhutch.org> # Schema as of 22 August 2019


### PR DESCRIPTION
We've been using tags a bit backwards.  Typically tags are markers of
when changes are merged/released/deployed, but we've only been creating
them when we need to rework changes.  Sometimes the tag names
incorporate the foreseen rework even though they identify the change
_before_ that rework takes place.  :-)

I would like to move to a tagging workflow where all branches that make
schema changes include a new sqitch tag.  Tags will then mark groups of
schema changes when they happen instead of after the fact, and it should
make reworks slightly nicer since a tag will already exist.

Tags used in this manner are effectively schema versions, which is a
very typical use case.  I think using [calendar versions](https://calver.org) makes sense
here for two main reasons:

  * It's easier to mint new tags since you don't have to know the last
    tag/version to create an appropriate new one.

  * The timeliness of a schema version is clear.

If a situation arises where we have two tags for a day, we can
disambiguate by suffixing with a, b, c, …, e.g. @2019-08-22a and
@2019-08-22b.
