### PR TITLE
longitudinal: update ETL to extract symptoms

### DIFF
--- a/lib/seattleflu/db/cli/command/etl/longitudinal.py
+++ b/lib/seattleflu/db/cli/command/etl/longitudinal.py
@@ -37,7 +37,7 @@ LOG = logging.getLogger(__name__)
 # longitudinal records lacking this revision number in their log.  If a
 # change to the ETL routine necessitates re-processing all longitudinal records,
 # this revision number should be incremented.
-REVISION = 2
+REVISION = 3
 
 
 @etl.command("longitudinal", help = __doc__)
@@ -224,7 +224,8 @@ def encounter_details(document: dict) -> dict:
                 "FluShot": flu_shot(document),
                 "AssignedSex": [sex(document)],
                 "HispanicLatino": hispanic_latino(document),
-                "MedicalInsurance": insurance(document)
+                "MedicalInsurance": insurance(document),
+                "Symptoms": symptoms(document),
             },
         }
 
@@ -369,6 +370,17 @@ def insurance(document: dict) -> list:
     }
 
     return [insurance_map.get(insurance_response, None)]
+
+
+def symptoms(document: dict) -> list:
+    """
+    Given a *document*, combines the unique parent-reported and RN-reported
+    symptoms into a list.
+    """
+    parent_reported_symptoms = document.get("sx_specific") or []
+    rn_reported_symptoms = document.get("rn_sx") or []
+
+    return list(set(parent_reported_symptoms + rn_reported_symptoms))
 
 
 def mark_processed(db, longitudinal_id: int, entry: Mapping) -> None:

--- a/lib/seattleflu/db/cli/command/longitudinal.py
+++ b/lib/seattleflu/db/cli/command/longitudinal.py
@@ -314,7 +314,6 @@ def duplicate_audere_keys(df: pd.DataFrame) -> pd.DataFrame:
         "smoking": "HouseholdSmoke",
         "enroll_site": "site",
         "flu_shot": "FluShot",
-        "sx_specific": "Symptoms",
         "illness_impact": "DailyInterference",
         "travel_type": "ChildrensRecentTravel",
         "sample_id": "barcode",


### PR DESCRIPTION
I _believe_ this fix is now incorporating symptoms into the `etl longitudinal` pipeline. 
However, I am unable to restore my local database from a copy of production since @tsibley's `location` changes. 
I'm hoping to debug this with him in person on Monday so I can fully test this PR. 