### PR TITLE
Exception logging

### DIFF
--- a/lib/seattleflu/__init__.py
+++ b/lib/seattleflu/__init__.py
@@ -4,6 +4,7 @@ Unified logging setup for modules in this package.
 import logging
 import os
 import os.path
+import sys
 from logging import StreamHandler
 from logging.handlers import SysLogHandler
 
@@ -65,3 +66,8 @@ if syslog_socket:
     )
 
     root_logger.addHandler(syslog)
+
+
+# Log any uncaught exceptions
+sys.excepthook = (lambda *args:
+    root_logger.error("Uncaught exception:", exc_info = args)) # type: ignore

--- a/lib/seattleflu/db/cli/command/etl/kit.py
+++ b/lib/seattleflu/db/cli/command/etl/kit.py
@@ -233,7 +233,7 @@ def upsert_kit_with_encounter(db: DatabaseSession,
         status = "updated"
         # Warn if kit is already linked to a different encounter!
         if kit.encounter_id and kit.encounter_id != encounter_id:
-            LOG.warning(f"Kit «{kit.id}» already linked to another encounter «{kit.encounter_id}»")
+            LOG.warning(f"Kit «{kit.id}» already linked to another encounter «{kit.encounter_id}», linking with «{encounter_id}» instead")
 
         kit = db.fetch_row("""
             update warehouse.kit
@@ -519,7 +519,7 @@ def upsert_kit_with_sample(db: DatabaseSession,
         # Warn if kit is already linked to a different sample!
         if (kit_sample_id and (sample.id != kit_sample_id)):
             LOG.warning(f"Kit «{kit.id}» already linked to another " +
-                        f"{sample_type} «{kit_sample_id}»")
+                        f"{sample_type} «{kit_sample_id}», linking with «{sample.id}» instead")
 
         kit = db.fetch_row(sql.SQL("""
             update warehouse.kit


### PR DESCRIPTION
Previously uncaught exceptions that were process-terminating were emitted to stderr, but not through the rest of the logging handlers (like /var/log/syslog).