### PR TITLE
Add current and modified timestamps to warehouse

### DIFF
--- a/schema/deploy/functions/update-modified-timestamp.sql
+++ b/schema/deploy/functions/update-modified-timestamp.sql
@@ -1,0 +1,17 @@
+-- Deploy seattleflu/schema:functions/update-modified-timestamp to pg
+
+begin;
+
+create or replace function warehouse.update_modified_timestamp() returns trigger as $$
+
+    begin
+        NEW.modified = now();
+        return new;
+    end;
+$$ language plpgsql
+    stable;
+
+comment on function warehouse.update_modified_timestamp is
+    'Updates the modified column timestamp with the current time on every update';
+
+commit;

--- a/schema/deploy/warehouse/encounter/timestamp.sql
+++ b/schema/deploy/warehouse/encounter/timestamp.sql
@@ -1,0 +1,20 @@
+-- Deploy seattleflu/schema:warehouse/encounter/timestamp to pg
+-- requires: warehouse/encounter
+
+begin;
+
+alter table warehouse.encounter
+    add column created timestamp with time zone,
+    add column modified timestamp with time zone;
+
+alter table warehouse.encounter
+    alter column created set default now(),
+    alter column modified set default now();
+
+comment on column warehouse.encounter.created is
+    'When the record was first processed by ID3C';
+
+comment on column warehouse.encounter.modified is
+    'When the record was last updated';
+
+commit;

--- a/schema/deploy/warehouse/encounter/triggers/update-modified-timestamp.sql
+++ b/schema/deploy/warehouse/encounter/triggers/update-modified-timestamp.sql
@@ -1,0 +1,12 @@
+-- Deploy seattleflu/schema:warehouse/encounter/triggers/update-modified-timestamp to pg
+-- requires: warehouse/encounter
+-- requires: functions/update-modified-timestamp
+
+begin;
+
+create trigger update_modified_timestamp
+    before update on warehouse.encounter
+    for each row
+        execute procedure warehouse.update_modified_timestamp();
+
+commit;

--- a/schema/deploy/warehouse/genomic-sequence/timestamp.sql
+++ b/schema/deploy/warehouse/genomic-sequence/timestamp.sql
@@ -1,0 +1,20 @@
+-- Deploy seattleflu/schema:warehouse/genomic-sequence/timestamp to pg
+-- requires: warehouse/genomic-sequence
+
+begin;
+
+alter table warehouse.genomic_sequence
+    add column created timestamp with time zone,
+    add column modified timestamp with time zone;
+
+alter table warehouse.genomic_sequence
+    alter column created set default now(),
+    alter column modified set default now();
+
+comment on column warehouse.genomic_sequence.created is
+    'When the record was first processed by ID3C';
+
+comment on column warehouse.genomic_sequence.modified is
+    'When the record was last updated';
+
+commit;

--- a/schema/deploy/warehouse/genomic-sequence/triggers/update-modified-timestamp.sql
+++ b/schema/deploy/warehouse/genomic-sequence/triggers/update-modified-timestamp.sql
@@ -1,0 +1,12 @@
+-- Deploy seattleflu/schema:warehouse/genomic-sequence/triggers/update-modified-timestamp to pg
+-- requires: warehouse/genomic-sequence
+-- requires: functions/update-modified-timestamp
+
+begin;
+
+create trigger update_modified_timestamp
+    before update on warehouse.genomic_sequence
+    for each row
+        execute procedure warehouse.update_modified_timestamp();
+
+commit;

--- a/schema/deploy/warehouse/presence_absence/timestamp.sql
+++ b/schema/deploy/warehouse/presence_absence/timestamp.sql
@@ -1,0 +1,20 @@
+-- Deploy seattleflu/schema:warehouse/presence_absence/timestamp to pg
+-- requires: warehouse/presence_absence
+
+begin;
+
+alter table warehouse.presence_absence
+    add column created timestamp with time zone,
+    add column modified timestamp with time zone;
+
+alter table warehouse.presence_absence
+    alter column created set default now(),
+    alter column modified set default now();
+
+comment on column warehouse.presence_absence.created is
+    'When the record was first processed by ID3C';
+
+comment on column warehouse.presence_absence.modified is
+    'When the record was last updated';
+
+commit;

--- a/schema/deploy/warehouse/presence_absence/triggers/update-modified-timestamp.sql
+++ b/schema/deploy/warehouse/presence_absence/triggers/update-modified-timestamp.sql
@@ -1,0 +1,12 @@
+-- Deploy seattleflu/schema:warehouse/presence_absence/triggers/update-modified-timestamp to pg
+-- requires: warehouse/presence_absence
+-- requires: functions/update-modified-timestamp
+
+begin;
+
+create trigger update_modified_timestamp
+    before update on warehouse.presence_absence
+    for each row
+        execute procedure warehouse.update_modified_timestamp();
+
+commit;

--- a/schema/deploy/warehouse/sample/timestamp.sql
+++ b/schema/deploy/warehouse/sample/timestamp.sql
@@ -1,0 +1,20 @@
+-- Deploy seattleflu/schema:warehouse/sample/timestamp to pg
+-- requires: warehouse/sample
+
+begin;
+
+alter table warehouse.sample
+    add column created timestamp with time zone,
+    add column modified timestamp with time zone;
+
+alter table warehouse.sample
+    alter column created set default now(),
+    alter column modified set default now();
+
+comment on column warehouse.sample.created is
+    'When the record was first processed by ID3C';
+
+comment on column warehouse.sample.modified is
+    'When the record was last updated';
+
+commit;

--- a/schema/deploy/warehouse/sample/triggers/update-modified-timestamp.sql
+++ b/schema/deploy/warehouse/sample/triggers/update-modified-timestamp.sql
@@ -1,0 +1,12 @@
+-- Deploy seattleflu/schema:warehouse/sample/triggers/update-modified-timestamp to pg
+-- requires: warehouse/sample
+-- requires: functions/update-modified-timestamp
+
+begin;
+
+create trigger update_modified_timestamp
+    before update on warehouse.sample
+    for each row
+        execute procedure warehouse.update_modified_timestamp();
+
+commit;

--- a/schema/deploy/warehouse/sequence-read-set/timestamp.sql
+++ b/schema/deploy/warehouse/sequence-read-set/timestamp.sql
@@ -1,0 +1,20 @@
+-- Deploy seattleflu/schema:warehouse/sequence-read-set/timestamp to pg
+-- requires: warehouse/sequence-read-set
+
+begin;
+
+alter table warehouse.sequence_read_set
+    add column created timestamp with time zone,
+    add column modified timestamp with time zone;
+
+alter table warehouse.sequence_read_set
+    alter column created set default now(),
+    alter column modified set default now();
+
+comment on column warehouse.sequence_read_set.created is
+    'When the record was first processed by ID3C';
+
+comment on column warehouse.sequence_read_set.modified is
+    'When the record was last updated';
+
+commit;

--- a/schema/deploy/warehouse/sequence-read-set/triggers/update-modified-timestamp.sql
+++ b/schema/deploy/warehouse/sequence-read-set/triggers/update-modified-timestamp.sql
@@ -1,0 +1,12 @@
+-- Deploy seattleflu/schema:warehouse/sequence-read-set/triggers/update-modified-timestamp to pg
+-- requires: warehouse/sequence-read-set
+-- requires: functions/update-modified-timestamp
+
+begin;
+
+create trigger update_modified_timestamp
+    before update on warehouse.sequence_read_set
+    for each row
+        execute procedure warehouse.update_modified_timestamp();
+
+commit;

--- a/schema/revert/functions/update-modified-timestamp.sql
+++ b/schema/revert/functions/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:functions/update-modified-timestamp from pg
+
+begin;
+
+drop function warehouse.update_modified_timestamp();
+
+commit;

--- a/schema/revert/warehouse/encounter/timestamp.sql
+++ b/schema/revert/warehouse/encounter/timestamp.sql
@@ -1,0 +1,9 @@
+-- Revert seattleflu/schema:warehouse/encounter/timestamp from pg
+
+begin;
+
+alter table warehouse.encounter
+    drop column created,
+    drop column modified;
+
+commit;

--- a/schema/revert/warehouse/encounter/triggers/update-modified-timestamp.sql
+++ b/schema/revert/warehouse/encounter/triggers/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/encounter/triggers/update-modified-timestamp from pg
+
+begin;
+
+drop trigger update_modified_timestamp on warehouse.encounter;
+
+commit;

--- a/schema/revert/warehouse/genomic-sequence/timestamp.sql
+++ b/schema/revert/warehouse/genomic-sequence/timestamp.sql
@@ -1,0 +1,9 @@
+-- Revert seattleflu/schema:warehouse/genomic-sequence/timestamp from pg
+
+begin;
+
+alter table warehouse.genomic_sequence
+    drop column created,
+    drop column modified;
+
+commit;

--- a/schema/revert/warehouse/genomic-sequence/triggers/update-modified-timestamp.sql
+++ b/schema/revert/warehouse/genomic-sequence/triggers/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/genomic-sequence/triggers/update-modified-timestamp from pg
+
+begin;
+
+drop trigger update_modified_timestamp on warehouse.genomic_sequence;
+
+commit;

--- a/schema/revert/warehouse/presence_absence/timestamp.sql
+++ b/schema/revert/warehouse/presence_absence/timestamp.sql
@@ -1,0 +1,9 @@
+-- Revert seattleflu/schema:warehouse/presence_absence/timestamp from pg
+
+begin;
+
+alter table warehouse.presence_absence
+    drop column created,
+    drop column modified;
+
+commit;

--- a/schema/revert/warehouse/presence_absence/triggers/update-modified-timestamp.sql
+++ b/schema/revert/warehouse/presence_absence/triggers/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/presence_absence/triggers/update-modified-timestamp from pg
+
+begin;
+
+drop trigger update_modified_timestamp on warehouse.presence_absence;
+
+commit;

--- a/schema/revert/warehouse/sample/timestamp.sql
+++ b/schema/revert/warehouse/sample/timestamp.sql
@@ -1,0 +1,9 @@
+-- Revert seattleflu/schema:warehouse/sample/timestamp from pg
+
+begin;
+
+alter table warehouse.sample
+    drop column created,
+    drop column modified;
+
+commit;

--- a/schema/revert/warehouse/sample/triggers/update-modified-timestamp.sql
+++ b/schema/revert/warehouse/sample/triggers/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/sample/triggers/update-modified-timestamp from pg
+
+begin;
+
+drop trigger update_modified_timestamp on warehouse.sample;
+
+commit;

--- a/schema/revert/warehouse/sequence-read-set/timestamp.sql
+++ b/schema/revert/warehouse/sequence-read-set/timestamp.sql
@@ -1,0 +1,9 @@
+-- Revert seattleflu/schema:warehouse/sequence-read-set/timestamp from pg
+
+begin;
+
+alter table warehouse.sequence_read_set
+    drop column created,
+    drop column modified;
+
+commit;

--- a/schema/revert/warehouse/sequence-read-set/triggers/update-modified-timestamp.sql
+++ b/schema/revert/warehouse/sequence-read-set/triggers/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/sequence-read-set/triggers/update-modified-timestamp from pg
+
+begin;
+
+drop trigger update_modified_timestamp on warehouse.sequence_read_set;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -122,3 +122,16 @@ shipping/views [shipping/views@2019-08-26] 2019-10-01T00:49:00Z Kairsten Fay <kf
 @2019-09-30 2019-10-01T01:35:37Z Kairsten Fay <kfay@fredhutch.org> # Add target organism lineage to presence_absence_result_v1
 roles/consensus-genome-processor/grants [roles/consensus-genome-processor/grants@2019-09-30] 2019-10-02T19:12:27Z Jover Lee <joverlee@fredhutch.org> # Rework grants to allow update on segment of warehouse.genomice_sequence
 @2019-10-02 2019-10-02T23:39:34Z Thomas Sibley <tsibley@fredhutch.org> # schema as of 2 October 2019
+
+functions/update-modified-timestamp 2019-10-04T01:14:53Z Kairsten Fay <kfay@fredhutch.org> # Update modified column timestamp
+warehouse/encounter/timestamp [warehouse/encounter] 2019-10-04T00:24:58Z Kairsten Fay <kfay@fredhutch.org> # Timestamp encounter records with date created and modified
+warehouse/encounter/triggers/update-modified-timestamp [warehouse/encounter functions/update-modified-timestamp] 2019-10-04T00:39:59Z Kairsten Fay <kfay@fredhutch.org> # Trigger to update modified timestamp on encounters
+warehouse/sample/timestamp [warehouse/sample] 2019-10-04T01:26:30Z Kairsten Fay <kfay@fredhutch.org> # Timestamp sample records with date created and modified
+warehouse/sample/triggers/update-modified-timestamp [warehouse/sample functions/update-modified-timestamp] 2019-10-04T01:29:39Z Kairsten Fay <kfay@fredhutch.org> # Trigger to update modified timestamp on samples
+warehouse/presence_absence/timestamp [warehouse/presence_absence] 2019-10-04T01:34:39Z Kairsten Fay <kfay@fredhutch.org> # Timestamp presence-absence records with date created and modified
+warehouse/presence_absence/triggers/update-modified-timestamp [warehouse/presence_absence functions/update-modified-timestamp] 2019-10-04T01:36:38Z Kairsten Fay <kfay@fredhutch.org> # Trigger to update modified timestamp on presence-absence tests
+warehouse/sequence-read-set/timestamp [warehouse/sequence-read-set] 2019-10-04T01:38:54Z Kairsten Fay <kfay@fredhutch.org> # Timestamp sequence read set records with date created and modified
+warehouse/sequence-read-set/triggers/update-modified-timestamp [warehouse/sequence-read-set functions/update-modified-timestamp] 2019-10-04T01:40:46Z Kairsten Fay <kfay@fredhutch.org> # Trigger to update modified timestamp on sequence read sets
+warehouse/genomic-sequence/timestamp [warehouse/genomic-sequence] 2019-10-04T01:43:50Z Kairsten Fay <kfay@fredhutch.org> # Timestamp genomic sequence records with date created and modified
+warehouse/genomic-sequence/triggers/update-modified-timestamp [warehouse/genomic-sequence functions/update-modified-timestamp] 2019-10-04T01:45:49Z Kairsten Fay <kfay@fredhutch.org> # Trigger to update modified timestamp on genomic sequences
+@2019-10-03 2019-10-04T01:46:57Z Kairsten Fay <kfay@fredhutch.org> # schema as of 3 October 2019

--- a/schema/verify/functions/update-modified-timestamp.sql
+++ b/schema/verify/functions/update-modified-timestamp.sql
@@ -1,0 +1,33 @@
+-- Verify seattleflu/schema:functions/update-modified-timestamp on pg
+
+begin;
+
+do $$
+    declare
+        pre_update_modified timestamp;
+        post_update_modified timestamp;
+    begin
+        create temporary table tests (
+            a text,
+            modified timestamp with time zone
+        );
+
+        insert into tests
+            values ('test', now() - interval '1 hour')
+            returning modified into strict pre_update_modified;
+
+        create trigger test_update_trigger
+            before update on tests
+            for each row
+                execute procedure warehouse.update_modified_timestamp();
+
+        update tests set a = 'test_update' where a = 'test'
+            returning modified into strict post_update_modified;
+
+        assert post_update_modified - pre_update_modified = interval '1 hour';
+
+    end
+$$;
+
+
+rollback;

--- a/schema/verify/warehouse/encounter/timestamp.sql
+++ b/schema/verify/warehouse/encounter/timestamp.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/encounter/timestamp on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/encounter/triggers/update-modified-timestamp.sql
+++ b/schema/verify/warehouse/encounter/triggers/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/encounter/triggers/update-modified-timestamp on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/genomic-sequence/timestamp.sql
+++ b/schema/verify/warehouse/genomic-sequence/timestamp.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/genomic-sequence/timestamp on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/genomic-sequence/triggers/update-modified-timestamp.sql
+++ b/schema/verify/warehouse/genomic-sequence/triggers/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/genomic-sequence/triggers/update-modified-timestamp on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/presence_absence/timestamp.sql
+++ b/schema/verify/warehouse/presence_absence/timestamp.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/presence_absence/timestamp on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/presence_absence/triggers/update-modified-timestamp.sql
+++ b/schema/verify/warehouse/presence_absence/triggers/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/presence_absence/triggers/update-modified-timestamp on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/sample/timestamp.sql
+++ b/schema/verify/warehouse/sample/timestamp.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/sample/timestamp on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/sample/triggers/update-modified-timestamp.sql
+++ b/schema/verify/warehouse/sample/triggers/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/sample/triggers/update-modified-timestamp on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/sequence-read-set/timestamp.sql
+++ b/schema/verify/warehouse/sequence-read-set/timestamp.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/sequence-read-set/timestamp on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/sequence-read-set/triggers/update-modified-timestamp.sql
+++ b/schema/verify/warehouse/sequence-read-set/triggers/update-modified-timestamp.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/sequence-read-set/triggers/update-modified-timestamp on pg
+
+begin;
+
+
+
+rollback;


### PR DESCRIPTION
Create new columns titled 'created' and 'modified' in the following
tables:
* `warehouse.encounters`
* `warehouse.sample`
* `warehouse.presence_absence`
* `warehouse.sequence_read_set`
* `warehouse.genomic_sequence`

These columns each have default values of the current timestamp. The
`modified` column is updated with a new timestamp via a trigger function
every time a record is updated. The trigger function modifies the
`modified` column even if the update changes are identical to the
previous changes.

---------
## TODO: 
~I didn't write any `verify` scripts so far because I wasn't sure what to test/how to test it.~
Currently, the `modified` column is updated on every update _even if_ the update results in no actual differences. Is this desirable?