### PR TITLE
Add `redcap-det` commands

### DIFF
--- a/lib/seattleflu/db/cli/command/__init__.py
+++ b/lib/seattleflu/db/cli/command/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "sequence_read_set",
     "consensus_genome",
     "reportable_conditions",
+    "redcap_det",
 ]
 
 

--- a/lib/seattleflu/db/cli/command/redcap_det.py
+++ b/lib/seattleflu/db/cli/command/redcap_det.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
 def redcap_det():
     pass
 
-@redcap_det.command("parse")
+@redcap_det.command("generate")
 @click.option("--project-id",
     metavar = "<project-id>",
     help = "The project ID for the REDCap project",
@@ -41,7 +41,7 @@ def redcap_det():
            "Format must be in YYYY-MM-DD HH:MM:SS (e.g.'2019-01-01 00:00:00')",
     required = True)
 
-def parse(project_id: str, token_name: str, start_date: str):
+def generate(project_id: str, token_name: str, start_date: str):
     """
     Generate DET notifications for REDCap records.
 

--- a/lib/seattleflu/db/cli/command/redcap_det.py
+++ b/lib/seattleflu/db/cli/command/redcap_det.py
@@ -161,7 +161,8 @@ def create_det_records(redcap_url: str, project: dict,
        'project_id': project['project_id'],
        'record': record['record_id'],
        'instrument': instrument,
-       instrument_complete: record[instrument_complete]
+       instrument_complete: record[instrument_complete],
+       '__generated_by__': 'id3c',
     }
 
     if 'redcap_event_name' in record:

--- a/lib/seattleflu/db/cli/command/redcap_det.py
+++ b/lib/seattleflu/db/cli/command/redcap_det.py
@@ -1,0 +1,180 @@
+"""
+Create data entry trigger (DET) records to insert into `receiving.redcap_det`
+for the REDCap records that have been created or modified since a given date.
+"""
+import os
+import click
+import logging
+import requests
+from typing import List
+from seattleflu.db.cli import cli
+from seattleflu.db.session import DatabaseSession
+from seattleflu.db.datatypes import as_json
+
+LOG = logging.getLogger(__name__)
+
+@cli.group("redcap-det", help = __doc__)
+def redcap_det():
+    pass
+
+@redcap_det.command("parse")
+@click.option("--project-id",
+    metavar = "<project-id>",
+    help = "The project ID for the REDCap project",
+    required = True)
+@click.option("--token-name",
+    metavar = "<token-name>",
+    help = "The name of the environment variable that holds the API token for the <project-id>",
+    required = True)
+@click.option("--start-date",
+    metavar = "<start-date>",
+    help = "The start date of REDCap records that have been created/modified. " +
+           "Format must be in YYYY-MM-DD HH:MM:SS (e.g.'2019-01-01 00:00:00')",
+    required = True)
+
+def parse(project_id: str, token_name: str, start_date: str):
+    """
+    GET REDCap records and parse them into REDCap DETs.
+
+    Requires environmental variables REDCAP_API_URL and <token_name>
+
+    All DET records parsed are output to stdout as newline-delimited JSON
+    records.  You will likely want to redirect stdout to a file.
+    """
+    LOG.debug(f"Getting all Kiosk Enrollment REDCap records that have been created/modified since {start_date}")
+
+    api_token = os.environ[token_name]
+    api_url = os.environ['REDCAP_API_URL']
+
+    # Assuming that the base url for a REDCap instance is
+    # just removing the 'api' from the API URL
+    redcap_url = api_url.rstrip('/').replace('api', '')
+
+    instruments = get_project_instruments(api_url, api_token)
+    redcap_records = get_redcap_records(api_url, api_token, start_date)
+
+    for record in redcap_records:
+        # Find all instruments within a record that have been mark completed
+        for instrument in instruments:
+            if record[(instrument + '_complete')] == '2':
+                print(as_json(create_det_records(redcap_url, project_id, record, instrument)))
+
+
+def get_project_instruments(api_url: str, api_token: str) -> List[str]:
+    """
+    Get REDCap instruments for a given project, which is determined by the
+    *api_token*
+    """
+    parameters = {
+        'content': 'instrument',
+        'format': 'json',
+        'token': api_token
+    }
+
+    instruments = get_redcap_data(api_url, parameters)
+    instrument_names = []
+
+    for instrument in instruments:
+        instrument_names.append(instrument['instrument_name'])
+
+    return instrument_names
+
+
+def get_redcap_records(api_url: str, api_token: str, start_date: str) -> List[dict]:
+    """
+    Get REDCap records for a given project, which is determined by the
+    *api_token*
+    """
+    parameters = {
+        'content': 'record',
+        'format': 'json',
+        'type': 'flat',
+        'token': api_token,
+        'dateRangeBegin': start_date
+    }
+
+    records = get_redcap_data(api_url, parameters)
+    return records
+
+
+def get_redcap_data(api_url: str, parameters: dict) -> List[dict]:
+    """
+    Get REDCap data by POST request to the REDCap API.
+
+    *api_url* specifies instance of REDCap and `api_token` within *parameters*
+    specifies the project.
+
+    Consult REDCap API documentation for required and optional parameters
+    to include in API request.
+    """
+    headers = {
+        'Content-type': 'application/x-www-form-urlencoded',
+        'Accept': 'application/json'
+    }
+
+    response = requests.post(api_url, data=parameters, headers=headers)
+
+    if response.status_code != 200:
+        raise Exception(f"REDCap returned response status code {response.status_code}")
+
+    return response.json()
+
+
+def create_det_records(redcap_url: str, project_id: str,
+                       record: dict, instrument: str) -> dict:
+    """
+    Create a "fake" DET record that matches the format of REDCap DETs:
+
+    \b
+    {
+        'redcap_url',
+        'project_id',
+        'record',
+        'instrument',
+        '<instrument>_complete',
+        'redcap_event_name' (for longitudinal projects only)
+    }
+    """
+    instrument_complete = instrument + '_complete'
+
+    det_record = {
+       'redcap_url': redcap_url,
+       'project_id': project_id,
+       'record': record['record_id'],
+       'instrument': instrument,
+       instrument_complete: record[instrument_complete]
+    }
+
+    if 'redcap_event_name' in record:
+        det_record['redcap_event_name'] = record['redcap_event_name']
+
+    return det_record
+
+
+@redcap_det.command("upload")
+@click.argument("det_file",
+    metavar = "<det.ndjson>",
+    type = click.File("r"))
+
+def upload(det_file):
+    """
+    Upload REDCap DET records into database receiving area.
+
+    <det.ndjson> must be a newline-delimited JSON file produced by this
+    command's sibling command.
+    """
+    db = DatabaseSession()
+
+    try:
+        LOG.info(f"Copying REDCap DET records from {det_file.name}")
+
+        row_count = db.copy_from_ndjson(("receiving", "redcap_det", "document"), det_file)
+
+        LOG.info(f"Received {row_count:,} DET records")
+        LOG.info("Committing all changes")
+        db.commit()
+
+    except:
+        LOG.info("Rolling back all changes; the database will not be modified")
+        db.rollback()
+        raise

--- a/lib/seattleflu/db/cli/command/redcap_det.py
+++ b/lib/seattleflu/db/cli/command/redcap_det.py
@@ -80,13 +80,7 @@ def get_project_instruments(api_url: str, api_token: str) -> List[str]:
     Get REDCap instruments for a given project, which is determined by the
     *api_token*
     """
-    parameters = {
-        'content': 'instrument',
-        'format': 'json',
-        'token': api_token
-    }
-
-    instruments = get_redcap_data(api_url, parameters)
+    instruments = get_redcap_data(api_url, api_token, {"content": "instrument"})
     instrument_names = []
 
     for instrument in instruments:
@@ -102,17 +96,16 @@ def get_redcap_records(api_url: str, api_token: str, since_date: str = None) -> 
     """
     parameters = {
         'content': 'record',
-        'format': 'json',
         'type': 'flat',
-        'token': api_token,
     }
 
     if since_date:
         parameters['dateRangeBegin'] = since_date
 
-    return get_redcap_data(api_url, parameters)
+    return get_redcap_data(api_url, api_token, parameters)
 
-def get_redcap_data(api_url: str, parameters: dict) -> List[dict]:
+
+def get_redcap_data(api_url: str, api_token: str, parameters: dict) -> List[dict]:
     """
     Get REDCap data by POST request to the REDCap API.
 
@@ -127,7 +120,13 @@ def get_redcap_data(api_url: str, parameters: dict) -> List[dict]:
         'Accept': 'application/json'
     }
 
-    response = requests.post(api_url, data=parameters, headers=headers)
+    data = {
+        **parameters,
+        'token': api_token,
+        'format': 'json',
+    }
+
+    response = requests.post(api_url, data=data, headers=headers)
 
     if response.status_code != 200:
         raise Exception(f"REDCap returned response status code {response.status_code}")

--- a/lib/seattleflu/db/cli/command/redcap_det.py
+++ b/lib/seattleflu/db/cli/command/redcap_det.py
@@ -1,6 +1,15 @@
 """
-Create data entry trigger (DET) records to insert into `receiving.redcap_det`
-for the REDCap records that have been created or modified since a given date.
+Generate and upload REDCap DET notifications.
+
+This command is useful for backfilling data entry trigger (DET) notifications
+for project records which missed the normal trigger process.  Two common
+scenarios when this happens are:
+
+1. The records were created/modified before trigger was enabled.
+
+\b
+2. The records were imported via REDCap's API or mobile app, which
+   bypasses the trigger.
 """
 import os
 import click
@@ -34,11 +43,13 @@ def redcap_det():
 
 def parse(project_id: str, token_name: str, start_date: str):
     """
-    GET REDCap records and parse them into REDCap DETs.
+    Generate DET notifications for REDCap records.
 
     Requires environmental variables REDCAP_API_URL and <token_name>
 
-    All DET records parsed are output to stdout as newline-delimited JSON
+    DET notifications are only output for completed instruments.
+
+    All DET notifications are output to stdout as newline-delimited JSON
     records.  You will likely want to redirect stdout to a file.
     """
     LOG.debug(f"Getting all Kiosk Enrollment REDCap records that have been created/modified since {start_date}")
@@ -123,7 +134,7 @@ def get_redcap_data(api_url: str, parameters: dict) -> List[dict]:
 def create_det_records(redcap_url: str, project_id: str,
                        record: dict, instrument: str) -> dict:
     """
-    Create a "fake" DET record that matches the format of REDCap DETs:
+    Create a "fake" DET notification that matches the format of REDCap DETs:
 
     \b
     {
@@ -158,7 +169,7 @@ def create_det_records(redcap_url: str, project_id: str,
 
 def upload(det_file):
     """
-    Upload REDCap DET records into database receiving area.
+    Upload REDCap DET notifications into database receiving area.
 
     <det.ndjson> must be a newline-delimited JSON file produced by this
     command's sibling command.

--- a/lib/seattleflu/db/cli/command/redcap_det.py
+++ b/lib/seattleflu/db/cli/command/redcap_det.py
@@ -142,7 +142,7 @@ def get_redcap_data(api_url: str, api_token: str, parameters: dict) -> Any:
 def create_det_records(redcap_url: str, project: dict,
                        record: dict, instrument: str) -> dict:
     """
-    Create a "fake" DET notification that matches the format of REDCap DETs:
+    Create a "fake" DET notification that mimics the format of REDCap DETs:
 
     \b
     {
@@ -151,7 +151,9 @@ def create_det_records(redcap_url: str, project: dict,
         'record',
         'instrument',
         '<instrument>_complete',
-        'redcap_event_name' (for longitudinal projects only)
+        'redcap_event_name',      // for longitudinal projects only
+        'redcap_repeat_instance',
+        'redcap_repeat_instrument',
     }
     """
     instrument_complete = instrument + '_complete'
@@ -162,6 +164,8 @@ def create_det_records(redcap_url: str, project: dict,
        'record': record['record_id'],
        'instrument': instrument,
        instrument_complete: record[instrument_complete],
+       'redcap_repeat_instance': record['redcap_repeat_instance'],
+       'redcap_repeat_instrument': record['redcap_repeat_instrument'],
        '__generated_by__': 'id3c',
     }
 

--- a/lib/seattleflu/db/cli/command/redcap_det.py
+++ b/lib/seattleflu/db/cli/command/redcap_det.py
@@ -33,8 +33,8 @@ def redcap_det():
     required = True)
 @click.option("--token-name",
     metavar = "<token-name>",
-    help = "The name of the environment variable that holds the API token for the <project-id>",
-    required = True)
+    help = "The name of the environment variable that holds the API token",
+    default = "REDCAP_API_TOKEN")
 @click.option("--start-date",
     metavar = "<start-date>",
     help = "The start date of REDCap records that have been created/modified. " +
@@ -45,7 +45,8 @@ def generate(project_id: str, token_name: str, start_date: str):
     """
     Generate DET notifications for REDCap records.
 
-    Requires environmental variables REDCAP_API_URL and <token_name>
+    Requires environmental variables REDCAP_API_URL and REDCAP_API_TOKEN (or
+    whatever you passed to --token-name).
 
     DET notifications are only output for completed instruments.
 

--- a/lib/seattleflu/db/cli/command/redcap_det.py
+++ b/lib/seattleflu/db/cli/command/redcap_det.py
@@ -127,9 +127,7 @@ def get_redcap_data(api_url: str, api_token: str, parameters: dict) -> List[dict
     }
 
     response = requests.post(api_url, data=data, headers=headers)
-
-    if response.status_code != 200:
-        raise Exception(f"REDCap returned response status code {response.status_code}")
+    response.raise_for_status()
 
     return response.json()
 

--- a/lib/seattleflu/db/cli/command/redcap_det.py
+++ b/lib/seattleflu/db/cli/command/redcap_det.py
@@ -14,6 +14,7 @@ scenarios when this happens are:
 import os
 import click
 import logging
+import re
 import requests
 from typing import List
 from seattleflu.db.cli import cli
@@ -55,9 +56,9 @@ def generate(project_id: str, token_name: str, since_date: str):
     api_token = os.environ[token_name]
     api_url = os.environ['REDCAP_API_URL']
 
-    # Assuming that the base url for a REDCap instance is
-    # just removing the 'api' from the API URL
-    redcap_url = api_url.rstrip('/').replace('api', '')
+    # Assuming that the base url for a REDCap instance is just removing the
+    # trailing 'api' from the API URL
+    redcap_url = re.sub(r'api/?$', '', api_url)
 
     if since_date:
         LOG.debug(f"Getting all records that have been created/modified since {since_date}")


### PR DESCRIPTION
Get REDCap records that have been created/modified since a provided
start date. Parse the records into "fake" DET records and print
as NDJSON. Upload created DET records to receiving.redcap_det

This creates "fake" DET records that mimics REDCap DETs but is missing `project_url` and `username`. I don't really see a way to parse these from the record data returned from REDCap, so if we do want to include them, I think they just need to be additional options in the `redcap-det parse` command. I don't think they are crucial to the ETL process so omitted for now.