### PR TITLE
api: Add endpoint to receive FHIR documents

### DIFF
--- a/lib/id3c/api/datastore.py
+++ b/lib/id3c/api/datastore.py
@@ -158,6 +158,27 @@ def store_redcap_det(session: DatabaseSession, document: str) -> None:
 
 @export
 @catch_permission_denied
+def store_fhir(session: DatabaseSession, document: str) -> None:
+    """
+    Store the given FHIR *document* (a **string**) in the backing
+    database using *session*.
+
+    Raises a :class:`BadRequestDatabaseError` exception if the given *document*
+    isn't valid and a :class:`Forbidden` exception if the database reports a
+    `permission denied` error.
+    """
+    with session, session.cursor() as cursor:
+        try:
+            cursor.execute(
+                "insert into receiving.fhir (document) values (%s)",
+                    (document,))
+
+        except (DataError, IntegrityError) as error:
+            raise BadRequestDatabaseError(error) from None
+
+
+@export
+@catch_permission_denied
 def fetch_metadata_for_augur_build(session: DatabaseSession) -> Iterable[Tuple[str]]:
     """
     Export metadata for augur build from shipping view

--- a/lib/id3c/api/routes.py
+++ b/lib/id3c/api/routes.py
@@ -129,6 +129,23 @@ def receive_redcap_det(*, session):
     return "", 204
 
 
+@api_v1.route("/receiving/fhir", methods = ['POST'])
+@content_types_accepted(["application/fhir+json"])
+@check_content_length
+@authenticated_datastore_session_required
+def receive_fhir(*, session):
+    """
+    Receive JSON representation of FHIR resources.
+    """
+    document = request.get_data(as_text = True)
+
+    LOG.debug(f'Received FHIR document {document}')
+
+    datastore.store_fhir(session, document)
+
+    return "", 204
+
+
 @api_v1.route("/shipping/augur-build-metadata", methods = ['GET'])
 @authenticated_datastore_session_required
 def get_metadata(session):

--- a/lib/id3c/api/static/index.html
+++ b/lib/id3c/api/static/index.html
@@ -70,6 +70,11 @@
     receiving area of the study database. Accepts any URL-encoded form data.
     </p>
 
+    <h3 class="code">POST /v1/receiving/fhir</h3>
+    <p>Stores the request data as a FHIR document in a receiving area of
+    the study database. This route expects a Content-Type of
+    <code>application/fhir+json</code>
+
     <h3 class="code">POST /v1/receiving/consensus-genome</h3>
     <p>Stores the request data as a consensus genome document in a receiving
     area of the study database.


### PR DESCRIPTION
This route expects Content-Type of `application/fhir+json`