### PR TITLE
Geocode, location lookup, and de-identify

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -23,6 +23,13 @@
             ],
             "version": "==19.3.0"
         },
+        "cachetools": {
+            "hashes": [
+                "sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae",
+                "sha256:8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a"
+            ],
+            "version": "==3.1.1"
+        },
         "certifi": {
             "hashes": [
                 "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
@@ -75,17 +82,17 @@
         },
         "fiona": {
             "hashes": [
-                "sha256:035414ebae4d2a55f61bda0bc55467c223504aad1826152122c8eafc4ba87819",
-                "sha256:2bc68b11580352a10a92da734dc09bd12348e45188d94416788681430ff0f02a",
-                "sha256:40e5a59029fb6b51824e7d2ab7b4d7de5f84c5c43ab189ec930e7aa7b7f6e278",
-                "sha256:659b0d66149ddcd324754495f8f4c6d5aefa92eebeb31fd82622b1c12b0d4443",
-                "sha256:711c3be73203b37812992089445a1e4e9d3d6b64e667389f7b15406e15a91e83",
-                "sha256:82760cfeffabd443eb7ada2a2c64d9a6eab3e14e7c25b1ff90186ba80a3ca625",
-                "sha256:8431aa3d790c5b509c4532ddb9a783df34d02a4e7b3175e5e75d058c09f81a90",
-                "sha256:8e8ce2f233b90d4faf03ed12c9826ab0193992c49685a0b9cf381e9fbfca8fa5",
-                "sha256:bbc6ba0ec3f6fc208b3f50df14374d5796258cfc30436fe3de312ed62d8f6223"
+                "sha256:16c3fcb0e5e4e73a12a08d2d1361650afc97da09516f4128c57d1ed3a3ea023a",
+                "sha256:210fb038b579fab38f35ddbdd31b9725f4d5099b3edfd4b87c983e5d47b79983",
+                "sha256:24fef046144ed1cf4527f822e5864f7a3e851cc93f9f709fb1b13314eac284b7",
+                "sha256:408677e6bc8e1102419092eb1d87f9b00ce785bb03d89515da497c9009281f22",
+                "sha256:7445b5be2224c773392ba91422620ac8754deee631b9ebed4b6311d9d564fe46",
+                "sha256:764e07073e89813527d6f254d753d9447346ce86db8df8ff7fad217bc7666a91",
+                "sha256:76b8ef2ba114d653a18ea7e87dc577309b77a13a1ea8dd21a09f85adf24f4b75",
+                "sha256:95d79fbb59f308135caa9520a49687933d938249890a31960e7e0ec4ebd955d2",
+                "sha256:c11e3330614f868e1e70aebfff3e9ee1e5e6fbfd08d711ac2d68261af4a0b0f9"
             ],
-            "version": "==1.8.8"
+            "version": "==1.8.9.post2"
         },
         "flask": {
             "hashes": [
@@ -199,39 +206,43 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:18d91a9199d1dfaa01ad645f7540370ba630bdcef09daaf9edf45b4b1bca0232",
-                "sha256:3f26e5da310a0c0b83ea50da1fd397de2640b02b424aa69be7e0784228f656c9",
-                "sha256:4182e32f4456d2c64619e97c58571fa5ca0993d1e8c2d9ca44916185e1726e15",
-                "sha256:426e590e2eb0e60f765271d668a30cf38b582eaae5ec9b31229c8c3c10c5bc21",
-                "sha256:5eb934a8f0dc358f0e0cdf314072286bbac74e4c124b64371395e94644d5d919",
-                "sha256:717928808043d3ea55b9bcde636d4a52d2236c246f6df464163a66ff59980ad8",
-                "sha256:8145f97c5ed71827a6ec98ceaef35afed1377e2d19c4078f324d209ff253ecb5",
-                "sha256:8744c84c914dcc59cbbb2943b32b7664df1039d99e834e1034a3372acb89ea4d",
-                "sha256:c1ac1d9590d0c9314ebf01591bd40d4c03d710bfc84a3889e5263c97d7891dee",
-                "sha256:cb2e197b7b0687becb026b84d3c242482f20cbb29a9981e43604eb67576da9f6",
-                "sha256:d4001b71ad2c9b84ff18b182cea22b7b6cbf624216da3ea06fb7af28d1f93165",
-                "sha256:d8930772adccb2882989ab1493fa74bd87d47c8ac7417f5dd3dd834ba8c24dc9",
-                "sha256:dfbb0173ee2399bc4ed3caf2d236e5c0092f948aafd0a15fbe4a0e77ee61a958",
-                "sha256:eebfbba048f4fa8ac711b22c78516e16ff8117d05a580e7eeef6b0c2be554c18",
-                "sha256:f1b21bc5cf3dbea53d33615d1ead892dfdae9d7052fa8898083bec88be20dcd2"
+                "sha256:0f484f43658a72e7d586a74978259657839b5bd31b903e963bb1b1491ab51775",
+                "sha256:0ffc6f9e20e77f3a7dc8baaad9c7fd25b858b084d3a2d8ce877bc3ea804e0636",
+                "sha256:23e0eac646419c3057f15eb96ab821964848607bf1d4ea5a82f26565986ec5e9",
+                "sha256:27c0603b15b5c6fa24885253bbe49a0c289381e7759385c59308ba4f0b166cf1",
+                "sha256:397fe360643fffc5b26b41efdf608647e3334a618d185a07976cd2dc51c90bce",
+                "sha256:3dbb3aa41c01504255bff2bd56944bdb915f6c9ce4bac7e2868efbace0b2a639",
+                "sha256:4e07c63247c59d61c6ebdbbb50196143cec6c5044403510c4e1a9d31854a83d6",
+                "sha256:4fa6d9235c6d2fecbeca82c3d326abd255866cafbfd37f66a0e826544e619760",
+                "sha256:56cb88b3876363d410a9d7724f43641ff164e2c9902d3266a648213e2efd5e6d",
+                "sha256:7ce1be1614455f83710b9a5dc1fc602a755bdddbe4dda1d41515062923a37bbf",
+                "sha256:ae1c96ffdeec376895e533107e0b0f9da16225a2184fbb24a5abc866769db75e",
+                "sha256:b6f27c9231be8a23de846f2302373991467dd8e397a4804d2614e8c5aa8d5a90",
+                "sha256:c6056067f894f9355bedcd168dd740aa849908d41c0a74756f6e38f203e941b3",
+                "sha256:ca91a19d1f0a280874a24dca44aadce42da7f3a7edb7e9ab7c7baad8febee2be",
+                "sha256:cbe4985f5c82a173f8cff6b7fe92d551addf99fb4ea9ff4eb4b1fe606bb098ec",
+                "sha256:e3e9893bfe80a8b8e6d56d36ebb7afe1df77db7b4068a6e2ef3636a91f6f1caa",
+                "sha256:e7b218e8711910dac3fed0d19376cd1ef0e386be5175965d332fd0c65d02a43b",
+                "sha256:ec48d18b8b63a5dbb838e8ea7892ee1034299e03f852bd9b6dffe870310414dd",
+                "sha256:f4ab6280277e3208a59bfa9f2e51240304d09e69ffb65abfb4a21d678b495f74"
             ],
-            "version": "==0.25.1"
+            "version": "==0.25.2"
         },
         "psycopg2": {
             "hashes": [
-                "sha256:128d0fa910ada0157bba1cb74a9c5f92bb8a1dca77cf91a31eb274d1f889e001",
-                "sha256:227fd46cf9b7255f07687e5bde454d7d67ae39ca77e170097cdef8ebfc30c323",
-                "sha256:2315e7f104681d498ccf6fd70b0dba5bce65d60ac92171492bfe228e21dcc242",
-                "sha256:4b5417dcd2999db0f5a891d54717cfaee33acc64f4772c4bc574d4ff95ed9d80",
-                "sha256:640113ddc943522aaf71294e3f2d24013b0edd659b7820621492c9ebd3a2fb0b",
-                "sha256:897a6e838319b4bf648a574afb6cabcb17d0488f8c7195100d48d872419f4457",
-                "sha256:8dceca81409898c870e011c71179454962dec152a1a6b86a347f4be74b16d864",
-                "sha256:b1b8e41da09a0c3ef0b3d4bb72da0dde2abebe583c1e8462973233fd5ad0235f",
-                "sha256:cb407fccc12fc29dc331f2b934913405fa49b9b75af4f3a72d0f50f57ad2ca23",
-                "sha256:d3a27550a8185e53b244ad7e79e307594b92fede8617d80200a8cce1fba2c60f",
-                "sha256:f0e6b697a975d9d3ccd04135316c947dd82d841067c7800ccf622a8717e98df1"
+                "sha256:47fc642bf6f427805daf52d6e52619fe0637648fe27017062d898f3bf891419d",
+                "sha256:72772181d9bad1fa349792a1e7384dde56742c14af2b9986013eb94a240f005b",
+                "sha256:8396be6e5ff844282d4d49b81631772f80dabae5658d432202faf101f5283b7c",
+                "sha256:893c11064b347b24ecdd277a094413e1954f8a4e8cdaf7ffbe7ca3db87c103f0",
+                "sha256:965c4c93e33e6984d8031f74e51227bd755376a9df6993774fd5b6fb3288b1f4",
+                "sha256:9ab75e0b2820880ae24b7136c4d230383e07db014456a476d096591172569c38",
+                "sha256:b0845e3bdd4aa18dc2f9b6fb78fbd3d9d371ad167fd6d1b7ad01c0a6cdad4fc6",
+                "sha256:dca2d7203f0dfce8ea4b3efd668f8ea65cd2b35112638e488a4c12594015f67b",
+                "sha256:ed686e5926929887e2c7ae0a700e32c6129abb798b4ad2b846e933de21508151",
+                "sha256:ef6df7e14698e79c59c7ee7cf94cd62e5b869db369ed4b1b8f7b729ea825712a",
+                "sha256:f898e5cc0a662a9e12bde6f931263a1bbd350cfb18e1d5336a12927851825bb6"
             ],
-            "version": "==2.8.3"
+            "version": "==2.8.4"
         },
         "python-dateutil": {
             "hashes": [
@@ -278,6 +289,12 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "smartystreets-python-sdk": {
+            "hashes": [
+                "sha256:c545be9f46640cd973c472b039323d03e7ae0f5df7ba866643e016bc4f43be59"
+            ],
+            "version": "==4.3.0"
         },
         "urllib3": {
             "hashes": [

--- a/lib/id3c/cli/command/__init__.py
+++ b/lib/id3c/cli/command/__init__.py
@@ -144,38 +144,8 @@ def load_input_from_file_or_stdin(filename: click.File) -> pd.DataFrame:
     return input_df
 
 
-def drop_columns_from_output(input_df: pd.DataFrame,
-                             output_df: pd.DataFrame,
-                             drop_columns: Tuple[str, ...]) -> pd.DataFrame:
-    """
-    Check all *drop_columns* exist within *input_df* and drop them from
-    *output_df*.
-
-    Raises a :class:`ColumnDoesNotExistError` if a column within *drop_columns*
-    does not exist in *input_df*.
-    """
-    input_columns = list(input_df.columns)
-
-    for column in drop_columns:
-        if column not in input_columns:
-            raise ColumnDoesNotExistError(dedent(f"""
-                Provided column to drop «{column}» does not exist.
-                Check input columns: {input_columns}
-            """))
-
-    return output_df.drop(columns=list(drop_columns))
-
-
 class UnsupportedFileExtensionError(ValueError):
     """
     Raised when the given *filename* ends with an unsupported extension.
-    """
-    pass
-
-
-class ColumnDoesNotExistError(ValueError):
-    """
-    Raised by :func:`drop_columns_from_output` if column provided does not
-    exist in *input_df*.
     """
     pass

--- a/lib/id3c/cli/command/__init__.py
+++ b/lib/id3c/cli/command/__init__.py
@@ -5,6 +5,7 @@ import click
 import logging
 import pandas as pd
 from functools import wraps
+from textwrap import dedent
 from id3c.db.session import DatabaseSession
 
 
@@ -97,3 +98,37 @@ def dump_ndjson(df: pd.DataFrame):
     Dates are formatted according to ISO 8601.
     """
     print(df.to_json(orient = "records", lines = True, date_format = "iso"))
+
+
+def load_file_as_dataframe(filename: str) -> pd.DataFrame:
+    """
+    Given a *filename*, loads its data as a pandas DataFrame.
+    Supported extensions are csv, tsv, xls, and xlsx.
+
+    Raises a :class: `UnsupportedFileExtensionError` if the given *filename*
+    ends with an unsupported extension.
+    """
+    supported_extensions = ('.csv', '.tsv', '.xls', '.xlsx')
+
+    if not filename.endswith(supported_extensions):
+        raise UnsupportedFileExtensionError(dedent(f"""
+            Unsupported file extension for file «{filename}».
+            Please choose from one of the following file extensions:
+                {supported_extensions}
+            """
+        ))
+
+    if filename.endswith(('.csv', '.tsv')):
+        separator = '\t' if filename.endswith('.tsv') else ','
+        df = pd.read_csv(filename, sep=separator, dtype=str, na_filter=False)
+    else:
+        df = pd.read_excel(filename, dtype=str, na_filter=False)
+
+    return df
+
+
+class UnsupportedFileExtensionError(ValueError):
+    """
+    Raised when the given *filename* ends with an unsupported extension.
+    """
+    pass

--- a/lib/id3c/cli/command/__init__.py
+++ b/lib/id3c/cli/command/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "redcap_det",
     "receiving",
     "geocode",
+    "de_identify",
 ]
 
 

--- a/lib/id3c/cli/command/__init__.py
+++ b/lib/id3c/cli/command/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "consensus_genome",
     "redcap_det",
     "receiving",
+    "geocode",
 ]
 
 

--- a/lib/id3c/cli/command/de_identify.py
+++ b/lib/id3c/cli/command/de_identify.py
@@ -1,0 +1,99 @@
+"""
+De-identify personally identifiable information (PII) by generating a hash.
+"""
+import click
+import logging
+import hashlib
+import pandas as pd
+from os import environ
+from sys import stdout
+from typing import Tuple
+from id3c.cli import cli
+from id3c.cli.command import (
+    load_input_from_file_or_stdin,
+    drop_columns_from_output
+)
+
+
+LOG = logging.getLogger(__name__)
+
+@cli.command("de-identify")
+@click.argument("columns",
+    metavar = "<columns>",
+    nargs = -1)
+
+@click.argument("filename",
+    metavar = "<filename.{csv,tsv,xls,xlsx}>",
+    type = click.File("r"))
+
+@click.option("--drop-input-columns",
+    is_flag = True,
+    help = "Optional flag to drop <columns> from output")
+
+def de_identify(columns, filename, drop_input_columns):
+    """
+    Given a <filename.{csv,tsv,xls,xlsx}> that contains personally identifiable
+    information (PII), generate a hash using specified <columns> and an environment
+    variable, "ID3C_DEIDENTIFY_SECRET".
+
+    <columns> are column names of fields to include in the hash. All values are
+    joined in the order of of the column names, so keep the order of column
+    names consistent!
+
+    <columns> values are expected to be canonicalized before running this
+    command!
+
+    <filename.{csv,tsv,xls,xlsx}> accepts `-` as a special file that refers
+    to stdin, assuming data is formatted as comma-separated values.
+    This is expected when piping output from `id3c geocode` directly into
+    this command.
+
+    Generated hashes are output to stdout along with input data as
+    comma-separated values. Provided <columns> can be dropped with the
+    --drop-input-columns flag.
+    """
+    input_df = load_input_from_file_or_stdin(filename)
+    fields_to_include = extract_fields_from_input(input_df, columns)
+    joined_fields = fields_to_include.apply(lambda x: ' '.join(x), axis=1)
+
+    hash_secret = environ.get('ID3C_DEIDENTIFY_SECRET')
+    if not hash_secret:
+        raise Exception("The environment variable ID3C_DEIDENTIFY_SECRET is required.")
+    hashes = joined_fields.map(lambda x: generate_hash(x, hash_secret) if x else None)
+
+    output_df = input_df.copy()
+    output_df['hash'] = hashes
+
+    if drop_input_columns:
+        output_df = drop_columns_from_output(input_df, output_df, columns)
+
+    output_df.to_csv(stdout, index = False)
+
+
+def extract_fields_from_input(input_df: pd.DataFrame,
+                              columns: Tuple[str, ...]) -> pd.DataFrame:
+    """
+    Extract specified *columns* from the *input* and return values as a
+    pandas DataFrame
+    """
+    try:
+        fields = input_df[list(columns)]
+
+    except KeyError as error:
+        LOG.error(f"{error}. Input columns: {list(input_df.columns)}")
+        raise error from None
+
+    return fields
+
+
+def generate_hash(identifier: str, secret: str) -> str:
+    """
+    Hash *secret* with *identifier* that is linked to identifiable records.
+    """
+    assert len(identifier) > 0, "Empty *identifier* provided!"
+    assert len(secret) > 0, "Empty *secret* provided!"
+
+    new_hash = hashlib.sha256()
+    new_hash.update(identifier.encode("utf-8"))
+    new_hash.update(secret.encode("utf-8"))
+    return new_hash.hexdigest()

--- a/lib/id3c/cli/command/de_identify.py
+++ b/lib/id3c/cli/command/de_identify.py
@@ -11,7 +11,6 @@ from typing import Tuple
 from id3c.cli import cli
 from id3c.cli.command import (
     load_input_from_file_or_stdin,
-    drop_columns_from_output
 )
 
 
@@ -65,7 +64,11 @@ def de_identify(columns, filename, drop_input_columns):
     output_df['hash'] = hashes
 
     if drop_input_columns:
-        output_df = drop_columns_from_output(input_df, output_df, columns)
+        try:
+            output_df.drop(columns = list(columns), inplace = True)
+        except KeyError as error:
+            LOG.error(f"{error}. Columns are: {list(output_df.columns)}")
+            raise error from None
 
     output_df.to_csv(stdout, index = False)
 

--- a/lib/id3c/cli/command/de_identify.py
+++ b/lib/id3c/cli/command/de_identify.py
@@ -31,6 +31,8 @@ LOG = logging.getLogger(__name__)
 
 def de_identify(columns, filename, drop_input_columns):
     """
+    De-identify data by generating a hash.
+
     Given a <filename.{csv,tsv,xls,xlsx}> that contains personally identifiable
     information (PII), generate a hash using specified <columns> and an environment
     variable, "ID3C_DEIDENTIFY_SECRET".

--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -1,0 +1,445 @@
+"""
+Geocode addresses that are listed in tabular format, with one address per
+row.
+"""
+import click
+import logging
+import pickle
+import pandas as pd
+import sys
+import json
+import yaml
+from os import environ, chdir
+from os.path import dirname
+from textwrap import dedent
+from cachetools import TTLCache
+from typing import Optional, Tuple, Dict, Any
+from smartystreets_python_sdk import StaticCredentials, ClientBuilder
+from smartystreets_python_sdk.us_street import Lookup
+from id3c.cli import cli
+
+
+LOG = logging.getLogger(__name__)
+
+CACHE_TTL = 60 * 60 * 24 * 365  # 1 year
+
+@cli.group("geocode", help = __doc__)
+def geocode():
+    pass
+
+@geocode.command("using-options")
+@click.argument("filename",
+    metavar = "<filename.{csv,tsv,xlsx,xls}>",
+    required = True,
+    type = click.Path(exists=True))
+
+@click.option("--street-column",
+    metavar = "<column>",
+    help = "Column name for address street",
+    required = True)
+
+@click.option("--secondary-column",
+    metavar = "<column>",
+    help = "Column name for address apartment,suite, or office number",
+    required = False)
+
+@click.option("--city-column",
+    metavar = "<column>",
+    help = "Column name for address city",
+    required = True)
+
+@click.option("--state-column",
+    metavar = "<column>",
+    help = "Column name for address state",
+    required = True)
+
+@click.option("--zipcode-column",
+    metavar = "<column>",
+    help = "Column name for address zipcode",
+    required = True)
+
+@click.option("--cache-file",
+    metavar = "<cache.pickle>",
+    help = "Local cache file for storing address lookups. Must be specified to cache lookups",
+    required = False,
+    type = click.Path())
+
+def geocode_using_options(**kwargs):
+    """
+    Geocode addresses listed in <filename.{csv,tsv,xlsx,xls}>.
+
+    Options specify column names to extract addresse parts for geocoding.
+    Of these, --street, --city, --state, and --zipcode are required.
+
+    Requires two environment variables SMARTYSTREETS_AUTH_ID and
+    SMARTYSTREETS_AUTH_TOKEN.
+
+    Geocoded addresses are output to stdout as comma-separated values, with
+    extra values for addresses latitude, longitude, and canonicalized address.
+    If an address is invalid, then these extra columns are left blank.
+    """
+    geocoded_addresses = get_geocoded_addresses(**kwargs)
+    geocoded_addresses.to_csv(sys.stdout, index=False)
+
+
+@geocode.command("using-config")
+@click.argument("filename",
+    metavar = "<filename.{csv,tsv,xlsx,xls}>",
+    required = True,
+    type = click.Path(exists=True))
+
+@click.argument("config_file",
+    metavar = "<config.yaml>",
+    required = True,
+    type = click.File("r"))
+
+def geocode_using_config(filename, config_file):
+    """
+    Geocode addresses listed in <filename.{csv,tsv,xlsx,xls}>
+    with column names and cache file specified by a <config.yaml>.
+    If cache is not specified in <config.yaml>, then lookups will not be
+    cached locally and will not be re-used for future lookups.
+
+    <config.yaml> must be a file with one YAML document in it.  The document
+    corresponds closely to the command-line options taken by the
+    "using-options" command (a sibling to this command).
+    For example:
+
+    \b
+        ---
+        cache: cache.pickle
+        columns:
+          street: "Street"
+          secondary: "Street2"
+          city: "City"
+          state: "State"
+          zipcode: "ZipCode"
+
+    Relative paths in <config.yaml> are treated relative to the containing
+    directory of the configuration file itself.
+
+    Requires two environment variables: SMARTYSTREETS_AUTH_ID and
+    SMARTYSTREETS_AUTH_TOKEN.
+
+    Geocoded addresses are output to stdout as comma-separated values, with
+    extra values for addresses latitude, longitude, and canonicalized address.
+    If an address is invalid, then these extra columns are left blank.
+    """
+    configs = list(yaml.safe_load_all(config_file))
+
+    if config_file.name != "<stdin>":
+        config_dir = dirname(config_file.name)
+
+        # dirname is the empty string if we're in the same directory as the
+        # config file.
+        if config_dir:
+            chdir(config_dir)
+
+    for config in configs:
+        try:
+            kwargs = {
+                "filename":          filename,
+                "street_column":     config["columns"]["street"],
+                "city_column":       config["columns"]["city"],
+                "state_column":      config["columns"]["state"],
+                "zipcode_column":    config["columns"]["zipcode"],
+                "secondary_column":  config["columns"].get("secondary"),
+                "cache_file":        config.get("cache")
+            }
+        except KeyError as key:
+            LOG.error(f"Required key «{key}» missing from config {config}")
+            raise key from None
+
+        geocoded_addresses = get_geocoded_addresses(**kwargs)
+        geocoded_addresses.to_csv(sys.stdout, index=False)
+
+
+def get_geocoded_addresses(*,
+                           filename,
+                           street_column,
+                           city_column,
+                           state_column,
+                           zipcode_column,
+                           secondary_column = None,
+                           cache_file = None):
+    """
+    Internal function powering :func:`geocode_using_options` and
+    :func:`geocode_using_config`.
+    """
+    LOG.debug(f"Reading addresses file {filename}")
+
+    cache = None
+    if cache_file:
+        cache = load_or_create_cache(cache_file)
+
+    address_column_map = {
+        'street': street_column,
+        'city': city_column,
+        'state': state_column,
+        'zipcode': zipcode_column,
+        'secondary': secondary_column
+    }
+
+    addresses_df = load_file_as_dataframe(filename)
+    addresses_df['std_address'] = addresses_df.apply(
+        lambda row: standardize_address(row, address_column_map),
+        axis='columns')
+
+    (addresses_df['lat'],
+     addresses_df['lng'],
+     addresses_df['canonicalized_address']) = zip(
+         *addresses_df['std_address'].apply(
+             lambda row: get_response_from_cache_or_geocoding(row, cache)))
+
+    if cache and cache_file:
+        save_cache(cache, cache_file)
+
+    return addresses_df
+
+
+def load_file_as_dataframe(filename: str) -> pd.DataFrame:
+    """
+    Given a *filename*, loads its data as a pandas DataFrame.
+
+    Raises a :class: `UnsupportedFileExtensionError` if the given *filename*
+    ends with an unsupported extension.
+    """
+    supported_extensions = ('.csv', '.tsv', '.xls', '.xlsx')
+
+    if not filename.endswith(supported_extensions):
+        raise UnsupportedFileExtensionError(dedent(f"""
+            Unsupported file extension for file «{filename}».
+            Please choose from one of the following file extensions:
+                {supported_extensions}
+            """
+        ))
+
+    if filename.endswith(('.csv', '.tsv')):
+        separator = '\t' if filename.endswith('.tsv') else ','
+        df = pd.read_csv(filename, sep=separator, dtype = str)
+    else:
+        df = pd.read_excel(filename, dtype = str)
+
+    return df
+
+
+def standardize_address(address_series: pd.Series,
+                        address_column_map: dict) -> dict:
+    """
+    Create standardized address dictionary from *address_series* with the
+    expected address keys for the SmartyStreets API provided in
+    *address_column_map*.
+
+    All address values are converted to uppercase and stripped of leading and
+    trailing whitespaces.
+    """
+    address_columns = list(filter(None, address_column_map.values()))
+
+    if not address_columns:
+        raise NoAddressColumnsFoundError(address_column_map)
+
+    address = address_series.to_dict()
+    std_address: Dict[str, str] = {}
+
+    for standardized_column, provided_column in address_column_map.items():
+        std_address[standardized_column] = None
+        if provided_column:
+            std_address[standardized_column] = address[provided_column].upper().strip()
+
+    return std_address
+
+
+def load_or_create_cache(cache_file: str) -> TTLCache:
+    """
+    Tries to load a pickled cache from the *cache_file*. If a cache
+    is not found at this location, creates a new one. Returns the cache.
+    """
+    try:
+        cache = pickle.load(open(cache_file, mode='rb'))
+    except FileNotFoundError:
+        LOG.warning("Couldn't find an existing cache file. Creating new cache.")
+        cache = TTLCache(maxsize=float('inf'), ttl=CACHE_TTL)
+    return cache
+
+
+def get_response_from_cache_or_geocoding(address: dict,
+                                         cache: TTLCache) -> Tuple[Any, Any, Any]:
+    """
+    Provided an *address* dict in a format that SmartyStreets US Address API
+    expects, get a response from the cache or by geocoding with API.
+    """
+    response = check_cache(address, cache)
+
+    if not response:
+        response = geocode_address(address)
+        save_to_cache(address, response, cache)
+
+    return response.get('lat'), response.get('lng'), response.get('canonicalized_address')
+
+
+def check_cache(address: dict, cache: TTLCache) -> Optional[dict]:
+    """
+    Given an *address* and a *cache*, checks if the *cache* exists.
+    If it does, returns the given value of the *address* key in the *cache*.
+    Returns nothing if the *address* key does not exist in the *cache*.
+    """
+    LOG.debug(f"Looking for address {address} in cache")
+
+    if cache:
+        try:
+            return cache[json.dumps(address, sort_keys=True)]
+        except KeyError:
+            LOG.warning("Item not found in cache.")
+    else:
+        LOG.warning("Cache does not exist or is empty.")
+
+    return None
+
+
+def geocode_address(address: dict) -> dict:
+    """
+    Given an *address* matching format expected for the SmartyStreets API,
+    returns a dict containing a canonicalized address and lat/long coordinates
+    from SmartyStreet's US Street geocoding API.
+    """
+    LOG.info("""Pinging SmartyStreets geocoding API""")
+    client = smartystreets_client_builder().build_us_street_api_client()
+
+    lookup = us_street_lookup(address)
+    if not lookup.street:
+        LOG.warning(dedent(f"""
+        No given street address for {address}.
+        Currently lookups are only possible with a street address."""))
+        return None
+
+    client.send_lookup(lookup)
+    result = lookup.result
+
+    if not result:
+        LOG.warning(f"Invalid address: no response from SmartyStreets.")
+
+    return parse_first_smartystreets_result(result)
+
+
+def smartystreets_client_builder():
+    """
+    Returns a new :class:`smartystreets_python_sdk.ClientBuilder` using
+    credentials from the required environment variables
+    ``SMARTYSTREETS_AUTH_ID`` and ``SMARTYSTREETS_AUTH_TOKEN``.
+    """
+    auth_id = environ.get('SMARTYSTREETS_AUTH_ID')
+    auth_token = environ.get('SMARTYSTREETS_AUTH_TOKEN')
+
+    if not auth_id and not auth_token:
+        raise Exception("The environment variables SMARTYSTREETS_AUTH_ID and SMARTYSTREETS_AUTH_TOKEN are required.")
+    elif not auth_id:
+        raise Exception("The environment variable SMARTYSTREETS_AUTH_ID is required.")
+    elif not auth_token:
+        raise Exception("The environment variable SMARTYSTREETS_AUTH_TOKEN is required.")
+
+    return ClientBuilder(StaticCredentials(auth_id, auth_token))
+
+
+def us_street_lookup(address: dict) -> Lookup:
+    """
+    Creates and returns a SmartyStreets US Street API Lookup object for a given
+    *address*.
+
+    Raises a :class:`InvalidAddressMappingError` if a Lookup property from the
+    SmartyStreets geocoding API is not present in the given *address* data.
+    """
+    lookup = Lookup()
+    try:
+        lookup.street = address['street']
+        lookup.secondary = address['secondary']
+        lookup.city = address['city']
+        lookup.state = address['state']
+        lookup.zipcode = address['zipcode']
+    except KeyError as e:
+        raise InvalidAddressMappingError(e)
+
+    lookup.candidates = 1
+    lookup.match = "Invalid"  # Most permissive
+    return lookup
+
+
+def parse_first_smartystreets_result(result: list) -> dict:
+    """
+    Given an address *result* from SmartyStreets geocoding API, parse the
+    canonicalized address and lat/lng information of the first result
+    to return as a dict.
+
+    If address is invalid and response is empty, then returns a dict with
+    empty string values
+    """
+    response = {
+        'canonicalized_address': '',
+        'lat': '',
+        'lng': ''
+    }
+
+    if len(result) > 0:
+        first_candidate = result[0]
+        address = ' '.join([
+            first_candidate.delivery_line_1,
+            first_candidate.last_line
+        ])
+        response['canonicalized_address'] = address
+        response['lat'] = first_candidate.metadata.latitude
+        response['lng'] = first_candidate.metadata.longitude
+
+    return response
+
+
+def save_to_cache(standardized_address: dict, response: dict, cache: TTLCache):
+    """
+    Given a *standardized_address* and its related *response* from the
+    SmartyStreets API, stores them as a key-value pair in the given *cache*,
+    overwriting the value for the existing *standardized_address* key if it
+    already existed in the *cache*.
+    """
+    cache[json.dumps(standardized_address, sort_keys=True)] = response
+
+
+def save_cache(cache: TTLCache, cache_file: str):
+    """ Given a *cache*, saves it to a hard-coded file `cache.pickle`. """
+    pickle.dump(cache, open(cache_file, mode='wb'))
+
+
+class UnsupportedFileExtensionError(ValueError):
+    """
+    Raised by :func:`load_file_as_dataframe` when the given *filename*
+    ends with an unsupported extension.
+    """
+    pass
+
+
+class InvalidAddressMappingError(KeyError):
+    """
+    Raised when a an *address_key* used in the SmartyStreets geocoding
+    API Lookup object is not present in the data to be transformed.
+    """
+    def __init__(self, address_key):
+        self.address_key = address_key
+
+    def __str__(self):
+        return dedent(f"""
+        {self.address_key} not found in the address mapping.
+        Is there an error in your `config.py`?
+        """)
+
+
+class NoAddressColumnsFoundError(InvalidAddressMappingError):
+    """
+    Raised by :func:`create_address_df` when a *address_columns_map*
+    has no values.
+    """
+    def __init__(self, address_columns_map):
+        self.address_columns_map = address_columns_map
+
+    def __str__(self):
+        return dedent(f"""
+        No address columns have been provided.
+        The expected columns are:
+            {self.address_columns_map.keys()}
+        """)

--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -415,7 +415,7 @@ class InvalidAddressMappingError(KeyError):
     def __str__(self):
         return dedent(f"""
         {self.address_key} not found in the address mapping.
-        Is there an error in your `config.py`?
+        Is there an error in your column map?
         """)
 
 

--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -17,6 +17,9 @@ from typing import Optional, Tuple, Dict, Any
 from smartystreets_python_sdk import StaticCredentials, ClientBuilder
 from smartystreets_python_sdk.us_street import Lookup
 from id3c.cli import cli
+from id3c.cli.command import (
+    load_file_as_dataframe
+)
 
 
 LOG = logging.getLogger(__name__)
@@ -195,32 +198,6 @@ def get_geocoded_addresses(*,
         save_cache(cache, cache_file)
 
     return addresses_df
-
-
-def load_file_as_dataframe(filename: str) -> pd.DataFrame:
-    """
-    Given a *filename*, loads its data as a pandas DataFrame.
-
-    Raises a :class: `UnsupportedFileExtensionError` if the given *filename*
-    ends with an unsupported extension.
-    """
-    supported_extensions = ('.csv', '.tsv', '.xls', '.xlsx')
-
-    if not filename.endswith(supported_extensions):
-        raise UnsupportedFileExtensionError(dedent(f"""
-            Unsupported file extension for file «{filename}».
-            Please choose from one of the following file extensions:
-                {supported_extensions}
-            """
-        ))
-
-    if filename.endswith(('.csv', '.tsv')):
-        separator = '\t' if filename.endswith('.tsv') else ','
-        df = pd.read_csv(filename, sep=separator, dtype = str)
-    else:
-        df = pd.read_excel(filename, dtype = str)
-
-    return df
 
 
 def standardize_address(address_series: pd.Series,
@@ -404,14 +381,6 @@ def save_to_cache(standardized_address: dict, response: dict, cache: TTLCache):
 def save_cache(cache: TTLCache, cache_file: str):
     """ Given a *cache*, saves it to a hard-coded file `cache.pickle`. """
     pickle.dump(cache, open(cache_file, mode='wb'))
-
-
-class UnsupportedFileExtensionError(ValueError):
-    """
-    Raised by :func:`load_file_as_dataframe` when the given *filename*
-    ends with an unsupported extension.
-    """
-    pass
 
 
 class InvalidAddressMappingError(KeyError):

--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -309,7 +309,7 @@ def check_cache(address: dict, cache: TTLCache) -> Optional[dict]:
     If it does, returns the given value of the *address* key in the *cache*.
     Returns nothing if the *address* key does not exist in the *cache*.
     """
-    LOG.debug(f"Looking for address {address} in cache")
+    LOG.debug(f"Looking for address in cache")
 
     if cache:
         try:
@@ -333,9 +333,7 @@ def geocode_address(address: dict) -> dict:
 
     lookup = us_street_lookup(address)
     if not lookup.street:
-        LOG.warning(dedent(f"""
-        No given street address for {address}.
-        Currently lookups are only possible with a street address."""))
+        LOG.warning(f"Missing street address; can't geocode")
         return None
 
     client.send_lookup(lookup)

--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -146,7 +146,7 @@ def geocode_using_config(filename, config_file):
 
     See `id3c geocode --help` for more information.
     """
-    configs = list(yaml.safe_load_all(config_file))
+    config = yaml.safe_load(config_file)
 
     if config_file.name != "<stdin>":
         config_dir = dirname(config_file.name)
@@ -156,23 +156,22 @@ def geocode_using_config(filename, config_file):
         if config_dir:
             chdir(config_dir)
 
-    for config in configs:
-        try:
-            kwargs = {
-                "filename":          filename,
-                "street_column":     config["columns"]["street"],
-                "city_column":       config["columns"]["city"],
-                "state_column":      config["columns"]["state"],
-                "zipcode_column":    config["columns"]["zipcode"],
-                "secondary_column":  config["columns"].get("secondary"),
-                "cache_file":        config.get("cache")
-            }
-        except KeyError as key:
-            LOG.error(f"Required key «{key}» missing from config {config}")
-            raise key from None
+    try:
+        kwargs = {
+            "filename":          filename,
+            "street_column":     config["columns"]["street"],
+            "city_column":       config["columns"]["city"],
+            "state_column":      config["columns"]["state"],
+            "zipcode_column":    config["columns"]["zipcode"],
+            "secondary_column":  config["columns"].get("secondary"),
+            "cache_file":        config.get("cache")
+        }
+    except KeyError as key:
+        LOG.error(f"Required key «{key}» missing from config {config}")
+        raise key from None
 
-        geocoded_addresses = get_geocoded_addresses(**kwargs)
-        geocoded_addresses.to_csv(sys.stdout, index=False)
+    geocoded_addresses = get_geocoded_addresses(**kwargs)
+    geocoded_addresses.to_csv(sys.stdout, index=False)
 
 
 def get_geocoded_addresses(*,

--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -1,6 +1,20 @@
 """
-Geocode addresses that are listed in tabular format, with one address per
-row.
+Geocode addresses into longitude/latitude.
+
+Input addresses must be in a tabular data format (CSV, TSV, or Excel) with only
+one address per row.
+
+Geocoding is performed by submitting addresses (with no other information) to
+an external service called SmartyStreets.  A SmartyStreets account is required.
+Credentials must be provided by the SMARTYSTREETS_AUTH_ID and
+SMARTYSTREETS_AUTH_TOKEN environment variables.
+
+Each address geocoded incurs a cost against the SmartyStreets account in use,
+so lookups are cached locally and re-used for up to a year when an address is
+encountered more than once.  For example, running a dataset through this
+command twice will only incur costs the first time.  The cache file should be
+protected as identifiable data since it contains the addresses themselves and
+the geocoding result.
 """
 import click
 import logging
@@ -43,7 +57,7 @@ def geocode():
 
 @click.option("--secondary-column",
     metavar = "<column>",
-    help = "Column name for address apartment,suite, or office number",
+    help = "Column name for address apartment, suite, or office number",
     required = False)
 
 @click.option("--city-column",
@@ -71,15 +85,17 @@ def geocode_using_options(**kwargs):
     """
     Geocode addresses listed in <filename.{csv,tsv,xlsx,xls}>.
 
-    Options specify column names to extract addresse parts for geocoding.
+    Options specify column names to extract address parts for geocoding.
     Of these, --street, --city, --state, and --zipcode are required.
 
-    Requires two environment variables SMARTYSTREETS_AUTH_ID and
+    Requires two environment variables: SMARTYSTREETS_AUTH_ID and
     SMARTYSTREETS_AUTH_TOKEN.
 
     Geocoded addresses are output to stdout as comma-separated values, with
     extra values for addresses latitude, longitude, and canonicalized address.
-    If an address is invalid, then these extra columns are left blank.
+    If an address cannot be geocoded, then these extra columns are left blank.
+
+    See `id3c geocode --help` for more information.
     """
     geocoded_addresses = get_geocoded_addresses(**kwargs)
     geocoded_addresses.to_csv(sys.stdout, index=False)
@@ -126,7 +142,9 @@ def geocode_using_config(filename, config_file):
 
     Geocoded addresses are output to stdout as comma-separated values, with
     extra values for addresses latitude, longitude, and canonicalized address.
-    If an address is invalid, then these extra columns are left blank.
+    If an address cannot be geocoded, then these extra columns are left blank.
+
+    See `id3c geocode --help` for more information.
     """
     configs = list(yaml.safe_load_all(config_file))
 

--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -107,7 +107,7 @@ def geocode_using_options(**kwargs):
 @click.argument("filename",
     metavar = "<filename.{csv,tsv,xlsx,xls}>",
     required = True,
-    type = click.Path(exists=True))
+    type = click.Path(exists=True, resolve_path=True))
 
 @click.argument("config_file",
     metavar = "<config.yaml>",
@@ -149,6 +149,9 @@ def geocode_using_config(filename, config_file):
     See `id3c geocode --help` for more information.
     """
     config = yaml.safe_load(config_file)
+
+    # The input data filename is fully-resolved by Click, so even if the
+    # filename is relative, it's safe to change directories before reading it.
 
     if config_file.name != "<stdin>":
         config_dir = dirname(config_file.name)

--- a/lib/id3c/cli/command/location.py
+++ b/lib/id3c/cli/command/location.py
@@ -43,7 +43,6 @@ from id3c.db.types import MinimalLocationRecord
 from id3c.db.session import DatabaseSession
 from id3c.cli.command import (
     load_input_from_file_or_stdin,
-    drop_columns_from_output
 )
 
 LOG = logging.getLogger(__name__)
@@ -359,7 +358,11 @@ def lookup(filename,
     output_df[f"{scale}_identifier"] = locations
 
     if drop_columns:
-        output_df = drop_columns_from_output(input_df, output_df, drop_columns)
+        try:
+            output_df.drop(columns = drop_columns, inplace = True)
+        except KeyError as error:
+            LOG.error(f"{error}. Columns are: {list(output_df.columns)}")
+            raise error from None
 
     output_df.to_csv(sys.stdout, index = False)
 

--- a/lib/id3c/cli/command/location.py
+++ b/lib/id3c/cli/command/location.py
@@ -419,5 +419,5 @@ def location_lookup(db: DatabaseSession,
         LOG.error(f"No location containing lat/lng «{lat_lng}» of scale «{scale}» found")
         return None
 
-    LOG.info(f"Found location {location.id} «{location.identifier}»")
+    LOG.debug(f"Found location {location.id} «{location.identifier}»")
     return location

--- a/lib/id3c/cli/command/location.py
+++ b/lib/id3c/cli/command/location.py
@@ -36,9 +36,10 @@ import id3c.db as db
 from io import StringIO
 from psycopg2.sql import SQL
 from textwrap import dedent
-from typing import Optional, Tuple, NamedTuple
+from typing import Optional, Tuple
 from id3c.cli import cli
 from id3c.db.datatypes import Json
+from id3c.db.types import MinimalLocationRecord
 from id3c.db.session import DatabaseSession
 from id3c.cli.command import load_file_as_dataframe
 
@@ -398,7 +399,7 @@ def extract_lat_lng_from_input(lookup_input: pd.DataFrame,
 
 def location_lookup(db: DatabaseSession,
                     lat_lng: Tuple[float, float],
-                    scale: str) -> Optional[NamedTuple]:
+                    scale: str) -> Optional[MinimalLocationRecord]:
     """
     Find location within warehouse of *scale* that contains
     *lat_lng* and return location id and identifier.

--- a/lib/id3c/cli/command/location.py
+++ b/lib/id3c/cli/command/location.py
@@ -416,7 +416,7 @@ def location_lookup(db: DatabaseSession,
         """, data)
 
     if not location:
-        LOG.error(f"No location containing lat/lng «{lat_lng}» of scale «{scale}» found")
+        LOG.error(f"No location of scale «{scale}» found for lat/lng")
         return None
 
     LOG.debug(f"Found location {location.id} «{location.identifier}»")

--- a/lib/id3c/cli/command/location.py
+++ b/lib/id3c/cli/command/location.py
@@ -332,8 +332,7 @@ def lookup(filename,
            lng_column,
            drop_columns):
     """
-    Given a <filename.{csv,tsv,xls,xlsx}> that contains latitudes and longitudes,
-    lookup the location within ID3C at the provided <scale>.
+    Lookup locations containing a given latitude and longitude.
 
     <filename.{csv,tsv,xls,xlsx}> accepts `-` as a special file that refers
     to stdin, assuming data is formatted as comma-separated values.

--- a/lib/id3c/cli/command/location.py
+++ b/lib/id3c/cli/command/location.py
@@ -302,11 +302,6 @@ def parse_features(path):
     metavar = "<filename.{csv,tsv,xls,xlsx}>",
     type = click.File("r"))
 
-@click.argument("drop-columns",
-    metavar = "<drop-columns>",
-    required = False,
-    nargs = -1)
-
 @click.option("--scale",
     metavar = "<scale>",
     default = "tract",
@@ -325,11 +320,15 @@ def parse_features(path):
     show_default = True,
     help = "Column name of longitude")
 
+@click.option("--drop-latlng-columns",
+    is_flag = True,
+    help = "Remove input lat/lng columns from the output")
+
 def lookup(filename,
            scale,
            lat_column,
            lng_column,
-           drop_columns):
+           drop_latlng_columns):
     """
     Lookup locations containing a given latitude and longitude.
 
@@ -337,9 +336,6 @@ def lookup(filename,
     to stdin, assuming data is formatted as comma-separated values.
     This is expected when piping output from `id3c geocode` directly into this
     command.
-
-    <drop-columns> can be used to specify input columns to not include in
-    the output.
 
     Lookup results are output to stdout as comma-separated values, with
     location identifier as <scale>_identifier.
@@ -357,9 +353,9 @@ def lookup(filename,
     output_df = input_df.copy()
     output_df[f"{scale}_identifier"] = locations
 
-    if drop_columns:
+    if drop_latlng_columns:
         try:
-            output_df.drop(columns = drop_columns, inplace = True)
+            output_df.drop(columns = [lat_column, lng_column], inplace = True)
         except KeyError as error:
             LOG.error(f"{error}. Columns are: {list(output_df.columns)}")
             raise error from None

--- a/lib/id3c/db/types.py
+++ b/lib/id3c/db/types.py
@@ -41,3 +41,7 @@ class GenomeRecord(NamedTuple):
     sample_id: int
     organism_id: int
     sequence_read_set_id: int
+
+class MinimalLocationRecord(NamedTuple):
+    id: int
+    identifier: str

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,3 +37,12 @@ ignore_missing_imports = True
 
 [mypy-psycopg2.*]
 ignore_missing_imports = True
+
+[mypy-cachetools]
+ignore_missing_imports = True
+
+[mypy-smartystreets_python_sdk]
+ignore_missing_imports = True
+
+[mypy-smartystreets_python_sdk.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ setup(
         "pyyaml",
         "deepdiff",
         "fiona",
+        "cachetools",
+        "smartystreets-python-sdk >= 4.0.1",
 
         # We use pkg_resources, which (confusingly) is provided by setuptools.
         # setuptools is nearly ever-present, but it can be missing!


### PR DESCRIPTION
Adds `geocode`, `location lookup` and `de-identify` to ID3C. 
See commit messages for specifics of each command. 

A couple things I would like to discuss:
1. the names of the `geocode` subcommands (naming is hard 😭)
2. whether we should limit `location lookup` to return only one location
3.  where should PII be standardized? currently `de-identify` expects values to already be canonicalized. 