### PR TITLE
Update etl presence-absence

### DIFF
--- a/lib/id3c/cli/command/__init__.py
+++ b/lib/id3c/cli/command/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "sequence_read_set",
     "consensus_genome",
     "redcap_det",
+    "receiving",
 ]
 
 

--- a/lib/id3c/cli/command/etl/presence_absence.py
+++ b/lib/id3c/cli/command/etl/presence_absence.py
@@ -118,6 +118,9 @@ def etl_presence_absence(*, action: str):
                     received_sample_id = str(received_sample["sampleId"])
                     chip = received_sample["chip"]
 
+                    # Guard against empty chip values
+                    assert chip, "Received bogus chip id"
+
                     for test_result in received_sample["targetResults"]:
                         test_result_target_id = test_result["geneTarget"]
                         LOG.debug(f"Processing target «{test_result_target_id}» for \

--- a/lib/id3c/cli/command/etl/presence_absence.py
+++ b/lib/id3c/cli/command/etl/presence_absence.py
@@ -64,6 +64,7 @@ def etl_presence_absence(*, action: str):
     LOG.debug("Fetching unprocessed presence-absence tests")
 
     presence_absence = db.cursor("presence_absence")
+    presence_absence.itersize = 1
     presence_absence.execute("""
         select presence_absence_id as id, document
           from receiving.presence_absence

--- a/lib/id3c/cli/command/etl/presence_absence.py
+++ b/lib/id3c/cli/command/etl/presence_absence.py
@@ -106,6 +106,10 @@ def etl_presence_absence(*, action: str):
                     received_sample_barcode = received_sample["investigatorId"]
                     LOG.info(f"Processing sample «{received_sample_barcode}»")
 
+                    if not received_sample.get("isCurrentExpressionResult"):
+                        LOG.warning(f"Skipping out-of-date results for sample «{received_sample_barcode}»")
+                        continue
+
                     received_sample_identifier = sample_identifier(db, received_sample_barcode)
 
                     if not received_sample_identifier:

--- a/lib/id3c/cli/command/etl/presence_absence.py
+++ b/lib/id3c/cli/command/etl/presence_absence.py
@@ -301,15 +301,15 @@ def update_details_nwgc_id(sample: Any, additional_details: dict) -> None:
     Add provided "nwgc_id" within *additional_details* to the existing array
     if it doesn't already exist
     """
-    exisiting_nwgc_ids = sample.details["nwgc_id"]
+    existing_nwgc_ids = sample.details["nwgc_id"]
     new_nwgc_ids = additional_details["nwgc_id"]
 
     # Extend details.nwgc_id to an array
     if not isinstance(sample.details["nwgc_id"], list):
-        exisiting_nwgc_ids = [sample.details["nwgc_id"]]
+        existing_nwgc_ids = [sample.details["nwgc_id"]]
 
     # Concatenate exisiting and new nwgc_ids and deduplicate
-    additional_details["nwgc_id"] = list(set(exisiting_nwgc_ids + new_nwgc_ids))
+    additional_details["nwgc_id"] = list(set(existing_nwgc_ids + new_nwgc_ids))
 
 
 def sample_identifier(db: DatabaseSession, barcode: str) -> Optional[str]:

--- a/lib/id3c/cli/command/etl/presence_absence.py
+++ b/lib/id3c/cli/command/etl/presence_absence.py
@@ -273,13 +273,10 @@ def update_sample(db: DatabaseSession,
 
     LOG.info(f"Found sample {sample.id} «{sample.identifier}»")
 
-    if (sample.get("details") and
-        sample.details.get("nwgc_id") and
-        additional_details):
-        update_details_nwgc_id(sample, additional_details)
-
     if additional_details:
         LOG.info(f"Updating sample {sample.id} «{sample.identifier}» details")
+
+        update_details_nwgc_id(sample, additional_details)
 
         sample = db.fetch_row("""
             update warehouse.sample
@@ -301,12 +298,15 @@ def update_details_nwgc_id(sample: Any, additional_details: dict) -> None:
     Add provided "nwgc_id" within *additional_details* to the existing array
     if it doesn't already exist
     """
-    existing_nwgc_ids = sample.details["nwgc_id"]
+    if not sample.details:
+        return
+
+    existing_nwgc_ids = sample.details.get("nwgc_id", [])
     new_nwgc_ids = additional_details["nwgc_id"]
 
     # Extend details.nwgc_id to an array
-    if not isinstance(sample.details["nwgc_id"], list):
-        existing_nwgc_ids = [sample.details["nwgc_id"]]
+    if not isinstance(existing_nwgc_ids, list):
+        existing_nwgc_ids = [existing_nwgc_ids]
 
     # Concatenate exisiting and new nwgc_ids and deduplicate
     additional_details["nwgc_id"] = list(set(existing_nwgc_ids + new_nwgc_ids))

--- a/lib/id3c/cli/command/receiving.py
+++ b/lib/id3c/cli/command/receiving.py
@@ -1,0 +1,60 @@
+"""
+Upload data into the receiving area.
+
+The receiving area of ID3C is mostly comprised of tables representing an
+ordered log of JSON documents to process into the warehouse.
+
+Typically there is a more tailored ID3C command to manipulate specific tables
+in the receiving area (such as `id3c manifest` or `id3c redcap-det`), but
+sometimes it is useful to more directly manipulate tables.  This is
+particularly true for receiving tables which are generally populated through
+the web API and do not have a more tailored command.
+"""
+import click
+import logging
+from id3c.cli import cli
+from id3c.db.session import DatabaseSession
+
+
+LOG = logging.getLogger(__name__)
+
+
+@cli.group("receiving", help = __doc__)
+def receiving():
+    pass
+
+
+@receiving.command("upload")
+
+@click.argument("table_name", metavar = "<table>")
+
+@click.argument("document_file",
+    metavar = "<documents.ndjson>",
+    type = click.File("r"))
+
+def upload(table_name, document_file):
+    """
+    Upload documents into a receiving table.
+
+    <table> must be the name of a table in the receiving schema which has a
+    "document" column.  All other columns in the table must be optional on
+    insert, as only "document" is provided.
+
+    <documents.ndjson> must be a newline-delimited JSON file containing one
+    document per line to insert as a table row.
+    """
+    db = DatabaseSession()
+
+    try:
+        LOG.info(f"Copying documents from {document_file.name}")
+
+        row_count = db.copy_from_ndjson(("receiving", table_name, "document"), document_file)
+
+        LOG.info(f"Received {row_count:,} {table_name} records")
+        LOG.info("Committing all changes")
+        db.commit()
+
+    except:
+        LOG.info("Rolling back all changes; the database will not be modified")
+        db.rollback()
+        raise

--- a/lib/id3c/cli/command/sequence_read_set.py
+++ b/lib/id3c/cli/command/sequence_read_set.py
@@ -161,8 +161,8 @@ def find_sample(db: DatabaseSession, nwgc_id: str) -> Optional[int]:
     sample = db.fetch_row("""
         select sample_id as id
           from warehouse.sample
-         where details ->> 'nwgc_id' = %s
-        """, (nwgc_id,))
+         where details @> '{"nwgc_id": [%s]}'
+        """, (int(nwgc_id),))
 
     if not sample:
         LOG.error(f"No sample with NWGC ID «{nwgc_id}» found")


### PR DESCRIPTION
Samplify will be sending documents with a top level "samples" key and
a "chip" key for each sample. 

~For each presence/absence result, the unique identifier will become "NWGC/`sampleId`/`chip`/`target_id`". `sampleId` and `chip` will both come from Samplify.
`target_id` for the target found or created within ID3C `warehouse.target`.~

`presence_absence.identifier` will become `NWGC/chip/sampleId/geneTarget` with all parts of the identifier coming from the Samplify document.

This change does bring up the question of how should we handle the old presence/absence results already within `warehouse.presence_absence`. Matthew did [offer](https://seattle-flu-study.slack.com/archives/CJU8RN2Q6/p1571943038028500?thread_ts=1571942534.026100&cid=CJU8RN2Q6) to send previous runs with chip information. In order for the results to be consistent and updated appropriately, I think it would be best to update the identifier for all presence/absence results to fit the new format. 