### PR TITLE
etl presence-absence: Preserve existing details when updating an existing row

### DIFF
--- a/lib/id3c/cli/command/etl/presence_absence.py
+++ b/lib/id3c/cli/command/etl/presence_absence.py
@@ -417,7 +417,7 @@ def upsert_presence_absence(db: DatabaseSession,
             set sample_id = excluded.sample_id,
                 target_id = excluded.target_id,
                 present   = excluded.present,
-                details = excluded.details
+                details = coalesce(presence_absence.details, '{}') || excluded.details
 
         returning presence_absence_id as id, identifier
         """, data)


### PR DESCRIPTION
Our custom reporting process stashes its log entries in presence/absence
details, but the log was being blown away when updates came in.  This
caused mass re-reporting today as we processed a large repush of
existing data.  More thorough testing (mea culpa) all the way through
the reporting process would have caught this.

This coalesce + append is the general pattern we should use so that
multiple things can cooperatively use the details column without knowing
about each other.

---

I haven't tested this yet, but we should!