### PR TITLE
Redcap DET end date

### DIFF
--- a/lib/id3c/cli/command/redcap_det.py
+++ b/lib/id3c/cli/command/redcap_det.py
@@ -40,8 +40,12 @@ def redcap_det():
     metavar = "<since-date>",
     help = "Limit to REDCap records that have been created/modified since the given date. " +
            "Format must be YYYY-MM-DD HH:MM:SS (e.g. '2019-01-01 00:00:00')")
+@click.option("--until-date",
+    metavar = "<until-date>",
+    help = "Limit to REDCap records that have been created/modified before the given date. " +
+           "Format must be YYYY-MM-DD HH:MM:SS (e.g. '2019-01-01 00:00:00')")
 
-def generate(project_id: int, token_name: str, since_date: str):
+def generate(project_id: int, token_name: str, since_date: str, until_date: str):
     """
     Generate DET notifications for REDCap records.
 
@@ -60,12 +64,16 @@ def generate(project_id: int, token_name: str, since_date: str):
 
     LOG.info(f"REDCap project #{project.id}: {project.title}")
 
-    if since_date:
+    if since_date and until_date:
+        LOG.debug(f"Getting all records that have been created/modified between {since_date} and {until_date}")
+    elif since_date:
         LOG.debug(f"Getting all records that have been created/modified since {since_date}")
+    elif until_date:
+        LOG.debug(f"Getting all records that have been created/modified before {until_date}")
     else:
         LOG.debug(f"Getting all records")
 
-    for record in project.records(since_date = since_date, raw = True):
+    for record in project.records(since_date = since_date, until_date = until_date, raw = True):
         # Find all instruments within a record that have been mark completed
         for instrument in project.instruments:
             if is_complete(instrument, record):

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -80,16 +80,24 @@ class Project:
         return self.records(ids = [record_id])
 
 
-    def records(self, since_date: str = None, ids: List[int] = None, raw: bool = False) -> List[dict]:
+    def records(self,
+                since_date: str = None,
+                until_date: str = None,
+                ids: List[int] = None,
+                raw: bool = False) -> List[dict]:
         """
         Fetch records for this REDCap project.
 
         Values are returned as string labels not numeric ("raw") codes.
 
         The optional *since_date* parameter can be used to limit records to
-        those created/modified after the given timestamp, which must be
-        formatted as ``YYYY-MM-DD HH:MM:SS`` in the REDCap server's configured
-        timezone.
+        those created/modified after the given timestamp.
+
+        The optional *until_date* parameter can be used to limit records to
+        those created/modified before the given timestamp.
+
+        Both *since_date* and *until_date* must be formatted as
+        ``YYYY-MM-DD HH:MM:SS`` in the REDCap server's configured timezone.
 
         The optional *ids* parameter can be used to limit results to the given
         record ids.
@@ -106,6 +114,9 @@ class Project:
 
         if since_date:
             parameters['dateRangeBegin'] = since_date
+
+        if until_date:
+            parameters['dateRangeEnd'] = until_date
 
         if ids is not None:
             parameters['records'] = ",".join(map(str, ids))


### PR DESCRIPTION
Add the ~`end_date`~ `until_date` option to generate DETs for records created/modified before the given timestamp.

If both `since_date` and ~`end_date`~ `until_date` are provided then only generates DETs for records created/modified in that timeframe. 