### PR TITLE
Install fuzzystrmatch extension to allow easier identifier/barcode correction

### DIFF
--- a/schema/deploy/fuzzystrmatch.sql
+++ b/schema/deploy/fuzzystrmatch.sql
@@ -1,0 +1,7 @@
+-- Deploy seattleflu/schema:fuzzystrmatch to pg
+
+begin;
+
+create extension fuzzystrmatch with schema public;
+
+commit;

--- a/schema/revert/fuzzystrmatch.sql
+++ b/schema/revert/fuzzystrmatch.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:fuzzystrmatch from pg
+
+begin;
+
+drop extension fuzzystrmatch;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -173,3 +173,4 @@ shipping/views [shipping/views@2020-01-14c] 2020-01-13T23:46:16Z Jover Lee <jove
 @2020-01-14d 2020-01-13T23:51:17Z Jover Lee <joverlee@fredhutch.org> # Schema as of 14 Jan 2020 after removing drop view statements
 
 functions/date_or_null 2020-01-17T20:15:20Z Jover Lee <joverlee@fredhutch.org> # A function to cast string to date or return null if invalid format
+fuzzystrmatch 2020-01-22T20:30:05Z Thomas Sibley <tsibley@fredhutch.org> # Install fuzzystrmatch extension to allow easier identifier/barcode correction

--- a/schema/verify/fuzzystrmatch.sql
+++ b/schema/verify/fuzzystrmatch.sql
@@ -1,0 +1,15 @@
+-- Verify seattleflu/schema:fuzzystrmatch on pg
+
+begin;
+
+select 1/(count(*) = 1)::int
+  from pg_catalog.pg_extension as e
+  left join pg_catalog.pg_namespace as n on (n.oid = e.extnamespace)
+ where extname = 'fuzzystrmatch'
+   and nspname = 'public';
+
+do $$ begin
+    assert levenshtein('foo', 'woo') = 1;
+end $$;
+
+rollback;


### PR DESCRIPTION
Actually performing correction is left as an exercise for the user
(ourselves, later!).

Unlike our existing `hamming_distance()` function used in minting
identifiers/barcodes, the Levenshtein distance functions work with
strings of different lengths (which is important for correction tasks).