### PR TITLE
location: add `hierarchy-by-feature` option

### DIFF
--- a/lib/id3c/cli/command/location.py
+++ b/lib/id3c/cli/command/location.py
@@ -219,6 +219,10 @@ def import_(features_path,
         hierarchy_df = pd.read_csv(hierarchy_by_feature, dtype=str)
         if "feature_identifier" not in hierarchy_df.columns:
             raise Exception("hierarchy_by_feature CSV must include 'feature_identifier' column")
+        duplicated_feature_identifier = hierarchy_df["feature_identifier"].duplicated(keep=False)
+        duplicates = hierarchy_df["feature_identifier"][duplicated_feature_identifier]
+        dup_identifiers = duplicates.unique().tolist()
+        assert len(dup_identifiers) == 0, f"Found duplicate feature_identifiers: {dup_identifiers}"
 
     locations = list(map(as_location, parse_features(features_path)))
 


### PR DESCRIPTION
This makes hierarchy dynamic per feature without modifying the GeoJSON.

`--hierarchy-by-feature` option takes a CSV file that must have the column "feature_identifier". All other column headers are assumed to be hierarchy keys.

This option overrides `--hierarchy-from` and can override `--hierarchy` if the they have the same keys.

My questions are:
1. should we have a hard coded list of supported hierarchy keys instead of just ingesting all columns within the CSV file?
1. how should we deal with duplicates of a feature_identifier? (it currently just takes the first record)