### PR TITLE
redcap-det generate for specific records

### DIFF
--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -112,6 +112,9 @@ class Project:
             'exportCheckboxLabel': 'true',
         }
 
+        assert bool(since_date or until_date) ^ (ids is not None), \
+            "The REDCap API does not support fetching records filtered by id *and* date."
+
         if since_date:
             parameters['dateRangeBegin'] = since_date
 


### PR DESCRIPTION
This is handy when testing and also may be useful if a specific set of records needs to be re-ingested due to a bad import.