### PR TITLE
redcap-det generate support for more diverse REDCap projects

### DIFF
--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -168,7 +168,7 @@ def get_redcap_record_from_det(det: dict) -> Optional[dict]:
     project_id = int(det["project_id"])
 
     try:
-        record_id = int(det["record"])
+        record_id = str(det["record"])
     except ValueError:
         return None
 

--- a/lib/id3c/cli/command/redcap_det.py
+++ b/lib/id3c/cli/command/redcap_det.py
@@ -30,7 +30,7 @@ def redcap_det():
 
 
 @redcap_det.command("generate")
-@click.argument("record-ids", nargs = -1, type = int)
+@click.argument("record-ids", nargs = -1)
 
 @click.option("--project-id",
     metavar = "<id>",
@@ -54,7 +54,7 @@ def redcap_det():
     help = "Limit to REDCap records that have been created/modified before the given date. " +
            "Format must be YYYY-MM-DD HH:MM:SS (e.g. '2019-01-01 00:00:00')")
 
-def generate(record_ids: List[int], project_id: int, token_name: str, since_date: str, until_date: str):
+def generate(record_ids: List[str], project_id: int, token_name: str, since_date: str, until_date: str):
     """
     Generate DET notifications for REDCap records.
 
@@ -125,8 +125,8 @@ def create_det_records(project: Project, record: dict, instrument: str) -> dict:
 
     det_record = {
        'redcap_url': project.base_url,
-       'project_id': str(project.id),       # REDCap DETs send project_id as a string
-       'record': str(record['record_id']),  # ...and record as well.
+       'project_id': str(project.id),                   # REDCap DETs send project_id as a string
+       'record': str(record[project.record_id_field]),  # ...and record as well.
        'instrument': instrument,
        instrument_complete: record[instrument_complete],
        'redcap_repeat_instance': record.get('redcap_repeat_instance'),

--- a/lib/id3c/cli/command/redcap_det.py
+++ b/lib/id3c/cli/command/redcap_det.py
@@ -54,7 +54,12 @@ def redcap_det():
     help = "Limit to REDCap records that have been created/modified before the given date. " +
            "Format must be YYYY-MM-DD HH:MM:SS (e.g. '2019-01-01 00:00:00')")
 
-def generate(record_ids: List[str], project_id: int, token_name: str, since_date: str, until_date: str):
+@click.option("--include-incomplete",
+    help = "Generate DET notifications for instruments marked as incomplete and unverified too, instead of only those marked complete",
+    is_flag = True,
+    flag_value = True)
+
+def generate(record_ids: List[str], project_id: int, token_name: str, since_date: str, until_date: str, include_incomplete: bool):
     """
     Generate DET notifications for REDCap records.
 
@@ -66,7 +71,9 @@ def generate(record_ids: List[str], project_id: int, token_name: str, since_date
     Requires environmental variables REDCAP_API_URL and REDCAP_API_TOKEN (or
     whatever you passed to --token-name).
 
-    DET notifications are only output for completed instruments.
+    DET notifications are output for all completed instruments for each record
+    by default.  Pass --include-incomplete to output DET notifications for
+    incomplete and unverified instruments too.
 
     All DET notifications are output to stdout as newline-delimited JSON
     records.  You will likely want to redirect stdout to a file.
@@ -99,9 +106,8 @@ def generate(record_ids: List[str], project_id: int, token_name: str, since_date
         raw = True)
 
     for record in records:
-        # Find all instruments within a record that have been mark completed
         for instrument in project.instruments:
-            if is_complete(instrument, record):
+            if include_incomplete or is_complete(instrument, record):
                 print(as_json(create_det_records(project, record, instrument)))
 
 

--- a/lib/id3c/cli/command/redcap_det.py
+++ b/lib/id3c/cli/command/redcap_det.py
@@ -20,28 +20,35 @@ from id3c.cli.redcap import Project, is_complete
 from id3c.db.session import DatabaseSession
 from id3c.db.datatypes import as_json
 
+
 LOG = logging.getLogger(__name__)
+
 
 @cli.group("redcap-det", help = __doc__)
 def redcap_det():
     pass
 
+
 @redcap_det.command("generate")
 @click.argument("record-ids", nargs = -1, type = int)
+
 @click.option("--project-id",
     metavar = "<id>",
     type = int,
     help = "The project id from which to fetch records.  "
            "Used as a sanity check that the correct API token is provided.",
     required = True)
+
 @click.option("--token-name",
     metavar = "<token-name>",
     help = "The name of the environment variable that holds the API token",
     default = "REDCAP_API_TOKEN")
+
 @click.option("--since-date",
     metavar = "<since-date>",
     help = "Limit to REDCap records that have been created/modified since the given date. " +
            "Format must be YYYY-MM-DD HH:MM:SS (e.g. '2019-01-01 00:00:00')")
+
 @click.option("--until-date",
     metavar = "<until-date>",
     help = "Limit to REDCap records that have been created/modified before the given date. " +
@@ -134,6 +141,7 @@ def create_det_records(project: Project, record: dict, instrument: str) -> dict:
 
 
 @redcap_det.command("upload")
+
 @click.argument("det_file",
     metavar = "<det.ndjson>",
     type = click.File("r"))

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -27,6 +27,7 @@ class Project:
     base_url: str
     _details: dict
     _instruments: List[str] = None
+    _fields: List[dict] = None
 
     def __init__(self, api_url: str, api_token: str, project_id: int) -> None:
         self.api_url = api_url
@@ -67,7 +68,30 @@ class Project:
         return self._instruments
 
 
-    def record(self, record_id: int) -> List[dict]:
+    @property
+    def fields(self) -> List[dict]:
+        """
+        Metadata about all fields in this REDCap project.
+        """
+        if not self._fields:
+            self._fields = self._fetch("metadata")
+
+        return self._fields
+
+
+    @property
+    def record_id_field(self) -> str:
+        """
+        Name of the field containing the unique id for each record.
+
+        For auto-numbered projects, this is typically ``record_id``, but for
+        other data entry projects, it can be any arbitrary name.  It is always
+        the first field in a project.
+        """
+        return self.fields[0]["field_name"]
+
+
+    def record(self, record_id: str) -> List[dict]:
         """
         Fetch the REDCap record *record_id* with all its instruments.
 
@@ -83,7 +107,7 @@ class Project:
     def records(self,
                 since_date: str = None,
                 until_date: str = None,
-                ids: List[int] = None,
+                ids: List[str] = None,
                 raw: bool = False) -> List[dict]:
         """
         Fetch records for this REDCap project.

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -136,7 +136,7 @@ class Project:
             'exportCheckboxLabel': 'true',
         }
 
-        assert bool(since_date or until_date) ^ (ids is not None), \
+        assert not ((since_date or until_date) and ids), \
             "The REDCap API does not support fetching records filtered by id *and* date."
 
         if since_date:


### PR DESCRIPTION
The REDCap project created by ITHS for our UW retrospective data pulls is setup a bit differently than the prospective projects created by Helen's team.

With these new options and fixes in place, the plan is to setup a cronjob which regularly generates and uploads DETs for the project to trigger a new REDCap ETL.