### PR TITLE
Upgrade pandas to newly released version 1.0.1

### DIFF
--- a/lib/id3c/__version__.py
+++ b/lib/id3c/__version__.py
@@ -12,4 +12,4 @@ This scheme is short, somewhat informative, avoids issues with multiple
 releases happening on the same day, and is unlikely to be misinterpreted as a
 full date.
 """
-__version__ = '2019.1'
+__version__ = '2020.1'

--- a/lib/id3c/cli/command/__init__.py
+++ b/lib/id3c/cli/command/__init__.py
@@ -123,9 +123,9 @@ def load_file_as_dataframe(filename: str) -> pd.DataFrame:
 
     if filename.endswith(('.csv', '.tsv')):
         separator = '\t' if filename.endswith('.tsv') else ','
-        df = pd.read_csv(filename, sep=separator, dtype=str, na_filter=False)
+        df = pd.read_csv(filename, sep=separator, dtype="string", na_filter=False)
     else:
-        df = pd.read_excel(filename, dtype=str, na_filter=False)
+        df = pd.read_excel(filename, dtype="string", na_filter=False)
 
     return df
 
@@ -137,7 +137,7 @@ def load_input_from_file_or_stdin(filename: click.File) -> pd.DataFrame:
     LOG.debug(f"Loading input from {filename.name}")
 
     if filename.name == "<stdin>":
-        input_df = pd.read_csv(filename, dtype=str, na_filter=False)
+        input_df = pd.read_csv(filename, dtype="string", na_filter=False)
     else:
         input_df = load_file_as_dataframe(filename.name)
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "fiona",
         "flask",
         "fsspec",
-        "pandas",
+        "pandas >=1.0.1,<2",
         "psycopg2 >=2.8,<3",
         "pyyaml",
         "requests",


### PR DESCRIPTION
Pandas finally has a non-zero major version number and a semver policy! \o/

Allows byte strings to be passed directly to pandas.read_excel() instead
of requiring that they're wrapped in ByteIO objects.  This is relevant
for the new remote URL support added to the manifest command, which I
tested under Pandas 1.x.  It doesn't work when using the older Pandas
pinned in our production environment, which I had pinned to avoid
backwards compat issues.

This version of Pandas also includes a nice true string dtype instead of
using the very generic object dtype.  The string dtype is more
restrictive than object and will only accept actual strings.  This is
what we wished we had when previously writing dtype=str.

A new deprecation warning about the future removal of pandas.np is
avoided by switching to the new true string dtype which uses the new
null value, pandas.NA.