### PR TITLE
Reduce log level from error → info when a sample cannot be found

### DIFF
--- a/lib/id3c/cli/command/etl/__init__.py
+++ b/lib/id3c/cli/command/etl/__init__.py
@@ -244,7 +244,7 @@ def find_sample(db: DatabaseSession, identifier: str, for_update = True) -> Any:
         """ + query_ending, (identifier,identifier,))
 
     if not sample:
-        LOG.error(f"No sample with identifier «{identifier}» found")
+        LOG.info(f"No sample with identifier «{identifier}» found")
         return None
 
     LOG.info(f"Found sample {sample.id} «{sample.identifier}»")

--- a/lib/id3c/cli/command/etl/consensus_genome.py
+++ b/lib/id3c/cli/command/etl/consensus_genome.py
@@ -78,6 +78,8 @@ def etl_consensus_genome(*, db: DatabaseSession):
                 record.document["sample_identifier"],
                 for_update=False)
 
+            assert sample, f"No sample found with identifier «{record.document['sample_identifier']}»"
+
             # Most of the time we expect to see existing sequence read sets,
             # but we also want to update the details log. However, the
             # only unique constraint on the sequence_read_set table is


### PR DESCRIPTION
This is a non-error condition for the callers, which check the return
value of find_sample() and take the appropriate action.  In some cases,
the caller will raise its own error.  In other cases, like the FHIR ETL,
the sample will be created and logging an error a) does not make sense
and b) makes the automated jobs noisy.  The decision is best left to the
caller.

The error level may have made more sense at a time when find_sample()
raised its own error instead of returning None.