### PR TITLE
etl fhir: handle literal references to Specimen

### DIFF
--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -180,7 +180,13 @@ def process_diagnostic_report_bundle_entry(db: DatabaseSession, bundle: Bundle, 
     LOG.debug(f"Processing DiagnosticReport Resource «{entry.fullUrl}».")
 
     for reference in resource.specimen:
-        if not matching_system(reference.identifier, INTERNAL_SYSTEM):
+        if not reference.identifier:
+            specimen = reference.resolved(Specimen)
+            reference.identifier = specimen.identifier[0]
+            if not matching_system(reference.identifier, f"{INTERNAL_SYSTEM}/sample"):
+                continue
+
+        elif not matching_system(reference.identifier, INTERNAL_SYSTEM):
             continue
 
         barcode = reference.identifier.value.strip()


### PR DESCRIPTION
Our internally created Diagnostic Reports have a literal reference to
a Specimen within the same bundle rather than a logical reference.
This updates the `process_diagnostic_report_bundle_entry` to handle both