### PR TITLE
Add default sheet_name to load_file_as_dataframe

### DIFF
--- a/lib/id3c/cli/io/pandas.py
+++ b/lib/id3c/cli/io/pandas.py
@@ -25,6 +25,8 @@ def load_file_as_dataframe(filename: str) -> pd.DataFrame:
     Given a *filename*, loads its data as a pandas DataFrame.
     Supported extensions are csv, tsv, xls, and xlsx.
 
+    If given an Excel workbook, defaults to loading only the first sheet.
+
     Raises a :class: `UnsupportedFileExtensionError` if the given *filename*
     ends with an unsupported extension.
     """
@@ -61,7 +63,7 @@ def load_input_from_file_or_stdin(filename: click.File) -> pd.DataFrame:
     return input_df
 
 
-def read_excel(io, sheet_name = None, na_filter: bool = True):
+def read_excel(io, sheet_name = 0, na_filter: bool = True):
     """
     Reads an Excel file while ensuring all values are treated as strings.
 


### PR DESCRIPTION
Without a default `sheet_name`, our `read_excel` function defaults to
`None`. Unfortuantely, this causes `pd.read_excel` to return a
`Dict[str, pd.DataFrame]` instead of a DataFrame as we would expect.

We're not specifying a sheet name as an argument in the
`load_file_as_dataframe` function, so hard-code the first sheet (0)
as the `sheet_name` argument.