### PR TITLE
Update FHIR ETL for Cepheid results

### DIFF
--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -180,16 +180,18 @@ def process_diagnostic_report_bundle_entry(db: DatabaseSession, bundle: Bundle, 
     LOG.debug(f"Processing DiagnosticReport Resource «{entry.fullUrl}».")
 
     for reference in resource.specimen:
+        barcode = None
         if not reference.identifier:
             specimen = reference.resolved(Specimen)
-            reference.identifier = specimen.identifier[0]
-            if not matching_system(reference.identifier, f"{INTERNAL_SYSTEM}/sample"):
+            barcode = identifier(specimen, f"{INTERNAL_SYSTEM}/sample").strip()
+            if not barcode:
                 continue
 
         elif not matching_system(reference.identifier, INTERNAL_SYSTEM):
             continue
 
-        barcode = reference.identifier.value.strip()
+        else:
+            barcode = reference.identifier.value.strip()
 
         LOG.debug(f"Looking up collected specimen barcode «{barcode}»")
         specimen_identifier = find_identifier(db, barcode)

--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -181,17 +181,16 @@ def process_diagnostic_report_bundle_entry(db: DatabaseSession, bundle: Bundle, 
 
     for reference in resource.specimen:
         barcode = None
+
         if not reference.identifier:
             specimen = reference.resolved(Specimen)
             barcode = identifier(specimen, f"{INTERNAL_SYSTEM}/sample").strip()
-            if not barcode:
-                continue
 
-        elif not matching_system(reference.identifier, INTERNAL_SYSTEM):
-            continue
-
-        else:
+        elif matching_system(reference.identifier, INTERNAL_SYSTEM):
             barcode = reference.identifier.value.strip()
+
+        if not barcode:
+            continue
 
         LOG.debug(f"Looking up collected specimen barcode «{barcode}»")
         specimen_identifier = find_identifier(db, barcode)

--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -817,6 +817,10 @@ def process_presence_absence_tests(db: DatabaseSession, report: DiagnosticReport
         snomed_code = matching_system_code(observation.code, SNOMED_SYSTEM)
         assert snomed_code, "No SNOMED code found"
 
+        # Skip results that are Inconclusive
+        if snomed_code == '911000124104':
+            continue
+
         # Most of the time we expect to see existing targets so a
         # select-first approach makes the most sense to avoid useless
         # updates.


### PR DESCRIPTION
1. Instead of assuming the first identifier is our internal identifier, find the correct identifier that matches our interal system.

2. Skip results that have snomed code '911000124104' which marks the result Inconclusive