### PR TITLE
Add a GitHub CODEOWNERS file so reviewers are automatically requested

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically request PR reviews from the dev team.
+*   @seattleflu/id3c-devs


### PR DESCRIPTION
A few less clicks on every PR!  Also enables some nice UI affordances on
GitHub.  Docs about CODEOWNERS at:

  https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners