### PR TITLE
etl redcap-det: allow raw coded values for multiple choice

### DIFF
--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -186,7 +186,7 @@ def get_redcap_record_from_det(det: dict, raw: bool) -> Optional[dict]:
     LOG.info(f"Fetching REDCap record {record_id}")
 
     project = CachedProject(api_url, api_token, project_id)
-    record = project.record(record_id, raw)
+    record = project.record(record_id, raw = raw)
 
     # XXX TODO: Handle records with repeating instruments or longitudinal
     # events.

--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -164,6 +164,7 @@ def command_for_project(name: str,
 def get_redcap_record_from_det(det: dict, raw: bool) -> Optional[dict]:
     """
     Fetch the REDCap record for the given *det* notification.
+
     The *raw* parameter indicates whether to pull the raw coded values or labels
     for multiple choice answers.
 

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -137,7 +137,7 @@ class Project:
         parameters = {
             'type': 'flat',
             'rawOrLabel': 'raw' if raw else 'label',
-            'exportCheckboxLabel': 'true',
+            'exportCheckboxLabel': 'true', # ignored by API if rawOrLabel == raw
         }
 
         assert not ((since_date or until_date) and ids), \

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -95,6 +95,10 @@ class Project:
         """
         Fetch the REDCap record *record_id* with all its instruments.
 
+        The optional *raw* parameter controls if numeric/coded values are
+        returned for multiple choice fields.  When false (the default),
+        string labels are returned.
+
         Note that in longitudinal projects with events or classic projects with
         repeating instruments, this may return more than one result.  The
         results will be share the same record id but be differentiated by the
@@ -126,9 +130,9 @@ class Project:
         The optional *ids* parameter can be used to limit results to the given
         record ids.
 
-        The optional *raw* parameter controls if numeric values are returned
-        for multiple choice fields.  When false (the default), string labels
-        are returned.
+        The optional *raw* parameter controls if numeric/coded values are
+        returned for multiple choice fields.  When false (the default), string
+        labels are returned.
         """
         parameters = {
             'type': 'flat',

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -91,7 +91,7 @@ class Project:
         return self.fields[0]["field_name"]
 
 
-    def record(self, record_id: str, raw: bool = False) -> List[dict]:
+    def record(self, record_id: str, *, raw: bool = False) -> List[dict]:
         """
         Fetch the REDCap record *record_id* with all its instruments.
 
@@ -108,7 +108,7 @@ class Project:
         return self.records(ids = [record_id], raw = raw)
 
 
-    def records(self,
+    def records(self, *,
                 since_date: str = None,
                 until_date: str = None,
                 ids: List[str] = None,

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -91,7 +91,7 @@ class Project:
         return self.fields[0]["field_name"]
 
 
-    def record(self, record_id: str) -> List[dict]:
+    def record(self, record_id: str, raw: bool = False) -> List[dict]:
         """
         Fetch the REDCap record *record_id* with all its instruments.
 
@@ -101,7 +101,7 @@ class Project:
         fields ``redcap_event_name``, ``redcap_repeat_instrument``, and
         ``redcap_repeat_instance``.
         """
-        return self.records(ids = [record_id])
+        return self.records(ids = [record_id], raw = raw)
 
 
     def records(self,


### PR DESCRIPTION
The default value for `raw_coded_values` is False, so we don't need to update the existing custom redcap-det ETLs. 

This will allow us to pull the coded values for the SCAN redcap project.