### PR TITLE
etl `upsert_location`: include new location's own hierarchy

### DIFF
--- a/lib/id3c/cli/command/etl/__init__.py
+++ b/lib/id3c/cli/command/etl/__init__.py
@@ -299,7 +299,7 @@ def upsert_location(db: DatabaseSession,
         values (%s, %s, %s)
 
         on conflict (scale, identifier) do update
-            set hierarchy = location.hierarchy || excluded.hierarchy
+            set hierarchy = coalesce(location.hierarchy, '') || excluded.hierarchy
 
         returning location_id as id, scale, identifier, hierarchy
         """, (scale, identifier, hierarchy))


### PR DESCRIPTION
Always include a new location's own `scale => identifier` in
its hierarchy.

On update, new hierarchy and exisiting hierarchy are concatenated, with
new hierarchy taking precedence if keys overlap.