### PR TITLE
Add the concept of a "primary" encounter location

### DIFF
--- a/schema/deploy/warehouse/encounter-location-relation.sql
+++ b/schema/deploy/warehouse/encounter-location-relation.sql
@@ -1,0 +1,20 @@
+-- Deploy seattleflu/schema:warehouse/encounter-location-relation to pg
+-- requires: warehouse/schema
+
+begin;
+
+create table warehouse.encounter_location_relation (
+    relation citext primary key,
+    priority integer unique
+);
+
+comment on table warehouse.encounter_location_relation is
+    'Controlled vocabulary for warehouse.encounter_location.relation';
+
+comment on column warehouse.encounter_location_relation.relation is
+    'A relation between an encounter and location, e.g. collection site, residence, workplace, etc.';
+
+comment on column warehouse.encounter_location_relation.priority is
+    'Arbitrary inter-relation ranking, where smaller numbers mean greater importance within this ID3C instance.  Used to determine the default "primary" location related to an encounter when there is more than one.';
+
+commit;

--- a/schema/deploy/warehouse/encounter-location-relation/data.sql
+++ b/schema/deploy/warehouse/encounter-location-relation/data.sql
@@ -1,0 +1,30 @@
+-- Deploy seattleflu/schema:warehouse/encounter-location-relation/data to pg
+-- requires: warehouse/encounter-location-relation
+
+begin;
+
+/* While the most important encounter location will be different for different
+ * analyses, a global default is useful for programatically choosing a single
+ * location from many.  Based on the Seattle Flu Study, where a person lives
+ * (their residence or temporary lodging) is most requested.  If we don't have
+ * that, then a workplace or school, which tend to be mutually exclusive, is
+ * better.  Both are places where participants spend lots of their time.
+ * Finally, the site of collection is better than nothing.  (It's assumed that
+ * collection sites are small in number and act as concentrators of
+ * participants.)
+ *
+ * While a global default is useful, the most important thing is that this
+ * table allows customization for each ID3C instance.
+ */
+insert into warehouse.encounter_location_relation
+    values
+        ('residence', 1),
+        ('lodging', 2),
+        ('workplace', 3),
+        ('school', 4),
+        ('site', 5)
+    on conflict (relation) do update set
+        priority = excluded.priority
+;
+
+commit;

--- a/schema/deploy/warehouse/encounter-location/relation-fk.sql
+++ b/schema/deploy/warehouse/encounter-location/relation-fk.sql
@@ -1,0 +1,16 @@
+-- Deploy seattleflu/schema:warehouse/encounter-location/relation-fk to pg
+-- requires: warehouse/encounter-location-relation
+
+begin;
+
+insert into warehouse.encounter_location_relation (relation)
+    select distinct relation from warehouse.encounter_location
+    on conflict (relation) do nothing
+;
+
+alter table warehouse.encounter_location
+    add constraint encounter_location_relation_fkey
+        foreign key (relation)
+        references warehouse.encounter_location_relation (relation);
+
+commit;

--- a/schema/deploy/warehouse/primary-encounter-location.sql
+++ b/schema/deploy/warehouse/primary-encounter-location.sql
@@ -1,0 +1,21 @@
+-- Deploy seattleflu/schema:warehouse/primary-encounter-location to pg
+-- requires: warehouse/encounter-location/relation-fk
+
+begin;
+
+create or replace view warehouse.primary_encounter_location as
+    select distinct on (encounter_id)
+        encounter_location.*
+    from
+        warehouse.encounter_location
+        join warehouse.encounter_location_relation using (relation)
+    order by
+        encounter_id,
+        priority nulls last
+;
+
+comment on view warehouse.primary_encounter_location is
+    'The, broadly speaking, "most important" location related to an encounter when there is more than one.  Uses priorities from warehouse.encounter_location_relation.';
+
+
+commit;

--- a/schema/revert/warehouse/encounter-location-relation.sql
+++ b/schema/revert/warehouse/encounter-location-relation.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/encounter-location-relation from pg
+
+begin;
+
+drop table warehouse.encounter_location_relation;
+
+commit;

--- a/schema/revert/warehouse/encounter-location-relation/data.sql
+++ b/schema/revert/warehouse/encounter-location-relation/data.sql
@@ -1,0 +1,13 @@
+-- Revert seattleflu/schema:warehouse/encounter-location-relation/data from pg
+
+begin;
+
+delete from warehouse.encounter_location_relation where relation in (
+    'residence',
+    'lodging',
+    'workplace',
+    'school',
+    'site'
+);
+
+commit;

--- a/schema/revert/warehouse/encounter-location/relation-fk.sql
+++ b/schema/revert/warehouse/encounter-location/relation-fk.sql
@@ -1,0 +1,8 @@
+-- Revert seattleflu/schema:warehouse/encounter-location/relation-fk from pg
+
+begin;
+
+alter table warehouse.encounter_location
+    drop constraint encounter_location_relation_fkey;
+
+commit;

--- a/schema/revert/warehouse/primary-encounter-location.sql
+++ b/schema/revert/warehouse/primary-encounter-location.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/primary-encounter-location from pg
+
+begin;
+
+drop view warehouse.primary_encounter_location;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -183,3 +183,8 @@ roles/redcap-det-processor/grants [roles/redcap-det-processor/grants@2020-02-06]
 
 shipping/views [shipping/views@2020-02-11] 2020-02-26T00:31:32Z Jover Lee <joverlee@fredhutch.org> # Add device to shipping.presence_absence_result
 @2020-02-25 2020-02-26T00:41:34Z Jover Lee <joverlee@fredhutch.org> # Schema as of 25 Feb 2020
+
+warehouse/encounter-location-relation [warehouse/schema] 2020-03-13T16:45:45Z Thomas Sibley <tsibley@fredhutch.org> # Control values for warehouse.encounter_location.relation
+warehouse/encounter-location-relation/data [warehouse/encounter-location-relation] 2020-03-13T16:51:37Z Thomas Sibley <tsibley@fredhutch.org> # Default encounter-location relations
+warehouse/encounter-location/relation-fk [warehouse/encounter-location-relation] 2020-03-13T17:04:43Z Thomas Sibley <tsibley@fredhutch.org> # Make warehouse.encounter_location.relation a FK
+warehouse/primary-encounter-location [warehouse/encounter-location/relation-fk] 2020-03-13T17:09:24Z Thomas Sibley <tsibley@fredhutch.org> # Core view to choose a single encounter-location

--- a/schema/verify/warehouse/encounter-location-relation.sql
+++ b/schema/verify/warehouse/encounter-location-relation.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/encounter-location-relation on pg
+
+begin;
+
+select pg_catalog.has_table_privilege('warehouse.encounter_location_relation', 'select');
+
+rollback;

--- a/schema/verify/warehouse/encounter-location-relation/data.sql
+++ b/schema/verify/warehouse/encounter-location-relation/data.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/encounter-location-relation/data on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/encounter-location/relation-fk.sql
+++ b/schema/verify/warehouse/encounter-location/relation-fk.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/encounter-location/relation-fk on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/primary-encounter-location.sql
+++ b/schema/verify/warehouse/primary-encounter-location.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/primary-encounter-location on pg
+
+begin;
+
+
+
+rollback;


### PR DESCRIPTION
Creates a framework for prioritizing encounter-locations by relation and
uses that in a new view that subsets warehouse.encounter_location to
just the "primary" rows.  A default set of relations and priorities is
added, but these can be tailored for each database since they are just
rows in a controlled vocabulary table.

This provides support to queries which want to only follow a single link
across the one-to-many relationship without hardcoding a specific
relation (e.g. to choose the "best" location available when the data is
sparse).