### PR TITLE
etl fhir: process patient preferred language

### DIFF
--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -428,7 +428,7 @@ def process_encounter(db: DatabaseSession, encounter: Encounter,
     patient = encounter.subject.resolved(Patient)
     patient_language = process_patient_language(patient)
 
-    individual  = process_encounter_individual(db, patient)
+    individual  = process_patient(db, patient)
 
     contained_resources = extract_contained_resources(encounter)
 
@@ -461,7 +461,7 @@ def process_patient_language(patient: Patient) -> Optional[str]:
     return matching_system_code(preferred_language[0].language, LANGUAGE_SYSTEM)
 
 
-def process_encounter_individual(db: DatabaseSession, patient: Patient) -> Any:
+def process_patient(db: DatabaseSession, patient: Patient) -> Any:
     """
     Returns an upserted individual using data from the given *patient*.
     """


### PR DESCRIPTION
Expects to find at most one preferred language per patient, and will error if it finds more than one preferred language.

Adds the language code to `encounter.details` as we have done in Y1 data. 