### PR TITLE
etl manifest: Add SCAN collection identifier set

### DIFF
--- a/lib/id3c/cli/command/etl/manifest.py
+++ b/lib/id3c/cli/command/etl/manifest.py
@@ -65,6 +65,7 @@ def etl_manifest(*, db: DatabaseSession):
             "collections-swab&send",
             "collections-swab&send-asymptomatic",
             "collections-self-test",
+            "collections-scan",
         },
         "rdt": {"collections-fluathome.org"}
     }


### PR DESCRIPTION
Add `collections-scan` to the list of hard-coded, acceptable collection
identifier sets for the manifest ETL.