### PR TITLE
labelmaker: Add new samples-haarvi layout

### DIFF
--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -184,6 +184,13 @@ class CollectionsCliaComplianceLayout(LabelLayout):
     reference = "scanpublichealth.org"
 
 
+class SamplesHaarviLayout(LabelLayout):
+    sku = "LCRY-2380"
+    barcode_type = "SAMPLE"
+    copies_per_barcode = 1
+    reference = "HAARVI"
+
+
 LAYOUTS = {
     "samples": SamplesLayout,
     "collections-scan": CollectionsScanLayout,
@@ -198,6 +205,7 @@ LAYOUTS = {
     "collections-clia-compliance": CollectionsCliaComplianceLayout,
     "kits-fluathome.org": KitsFluAtHomeLayout,
     "test-strips-fluathome.org": _TestStripsFluAtHomeLayout,
+    "samples-haarvi": SamplesHaarviLayout,
 }
 
 


### PR DESCRIPTION
Add a new sample (aliquot) barcode collection for HAARVI as requested by
Caitlin. She wanted singlet barcodes in the triplicate format (i.e.
small barcodes) for the HAARVI sub-study.

---------------------------------------

As far as I know, new identifier sets are added manually (outside of sqitch) to ID3C. So, I would have to run the following SQL before deploying this branch:
```sql
insert into warehouse.identifier_set (name, description) values ('samples-haarvi', 'Aliquoting sample barcodes for collections-haarvi');
```