### PR TITLE
labelmaker: update SamplesLayout to print duplicates

### DIFF
--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -95,19 +95,19 @@ class LCRY1100TriplicateLayout(LabelLayout):
 class SamplesLayout(LabelLayout):
     sku = "LCRY-2380"
     barcode_type = "SAMPLE"
-    copies_per_barcode = 3
+    copies_per_barcode = 2
     reference = "seattleflu.org"
 
     def blanks_before(self, barcode_number):
         """
-        Each barcode maps to 3 labels.  Each row is 7 labels wide, so for
-        better UX we want all labels in the 4th column to be blank.  We can
+        Each barcode maps to 2 labels.  Each row is 7 labels wide, so for
+        better UX we want all labels in the 7th column to be blank.  We can
         express this without using a mutable label sequence number by
-        inserting a blank label before every other barcode (e.g. the 2nd
-        barcode normally would start filling in the 4th label; by inserting a
-        blank, it starts filling in from the 5th label).
+        inserting a blank label before every fourth barcode (e.g. the 4th
+        barcode normally would start filling in the 7th label; by inserting a
+        blank, it starts filling in from the 1st label of the next row).
         """
-        return 1 if barcode_number % 2 == 0 else 0
+        return 1 if barcode_number > 1 and (barcode_number - 1) % 3 == 0 else 0
 
 
 class CollectionsSeattleFluLayout(LabelLayout):


### PR DESCRIPTION
Sample barcodes are only needed in duplicate since the lab is no longer
doing the C aliquot.

This updates the labels to print duplicate barcodes, with 3 pairs
per row and the last column blank.