### PR TITLE
Sample collection date

### DIFF
--- a/schema/deploy/warehouse/sample/collection-date.sql
+++ b/schema/deploy/warehouse/sample/collection-date.sql
@@ -1,0 +1,12 @@
+-- Deploy seattleflu/schema:warehouse/sample/collection-date to pg
+-- requires: warehouse/sample
+
+begin;
+
+alter table warehouse.sample
+    add column collected date;
+
+comment on column warehouse.sample.collected is
+    'Date when the sample was collected';
+
+commit;

--- a/schema/revert/warehouse/sample/collection-date.sql
+++ b/schema/revert/warehouse/sample/collection-date.sql
@@ -1,0 +1,8 @@
+-- Revert seattleflu/schema:warehouse/sample/collection-date from pg
+
+begin;
+
+alter table warehouse.sample
+    drop column collected;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -191,3 +191,4 @@ warehouse/primary-encounter-location [warehouse/encounter-location/relation-fk] 
 @2020-03-13 2020-04-21T23:31:54Z Jover Lee <joverlee@fredhutch.org> # Schema as of 13 March 2020
 
 warehouse/sample/collection-date [warehouse/sample] 2020-04-20T18:49:35Z Jover Lee <joverlee@fredhutch.org> # Add collection-date to samples
+@2020-04-20 2020-04-20T19:47:27Z Jover Lee <joverlee@fredhutch.org> # Schema as of 20 April 2020

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -189,3 +189,5 @@ warehouse/encounter-location-relation/data [warehouse/encounter-location-relatio
 warehouse/encounter-location/relation-fk [warehouse/encounter-location-relation] 2020-03-13T17:04:43Z Thomas Sibley <tsibley@fredhutch.org> # Make warehouse.encounter_location.relation a FK
 warehouse/primary-encounter-location [warehouse/encounter-location/relation-fk] 2020-03-13T17:09:24Z Thomas Sibley <tsibley@fredhutch.org> # Core view to choose a single encounter-location
 @2020-03-13 2020-04-21T23:31:54Z Jover Lee <joverlee@fredhutch.org> # Schema as of 13 March 2020
+
+warehouse/sample/collection-date [warehouse/sample] 2020-04-20T18:49:35Z Jover Lee <joverlee@fredhutch.org> # Add collection-date to samples

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -188,3 +188,4 @@ warehouse/encounter-location-relation [warehouse/schema] 2020-03-13T16:45:45Z Th
 warehouse/encounter-location-relation/data [warehouse/encounter-location-relation] 2020-03-13T16:51:37Z Thomas Sibley <tsibley@fredhutch.org> # Default encounter-location relations
 warehouse/encounter-location/relation-fk [warehouse/encounter-location-relation] 2020-03-13T17:04:43Z Thomas Sibley <tsibley@fredhutch.org> # Make warehouse.encounter_location.relation a FK
 warehouse/primary-encounter-location [warehouse/encounter-location/relation-fk] 2020-03-13T17:09:24Z Thomas Sibley <tsibley@fredhutch.org> # Core view to choose a single encounter-location
+@2020-03-13 2020-04-21T23:31:54Z Jover Lee <joverlee@fredhutch.org> # Schema as of 13 March 2020

--- a/schema/verify/warehouse/sample/collection-date.sql
+++ b/schema/verify/warehouse/sample/collection-date.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/sample/collection-date on pg
+
+begin;
+
+
+
+rollback;


### PR DESCRIPTION
Add `collection_date` to `warehouse.sample` and ingest this field from the manifest ETL.

I've added a `validate_date` function to clean up the manually entered collection date column from the aliquoting manifest. 
1. Do we want to use this to check that the date is not too old or a future date as well? (We currently have a sample from 1911-04-04 😆 )
2. Do we want `sample.details.date` to hold the raw value from the aliquoting sheet or should we update that to be the cleaned up date value as well?