### PR TITLE
Scan follow up fhir

### DIFF
--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -483,13 +483,10 @@ def process_encounter_reason(encounter: Encounter) -> Optional[List[dict]]:
     if not encounter.reasonCode:
         return None
 
-    reason_codes: List[Coding] = []
-
-    for codeable_concept in encounter.reasonCode:
-        codes = codeable_concept.coding
-        reason_codes.extend(codes)
-
-    return [r.as_json() for r in reason_codes]
+    return [
+        coding.as_json()
+        for concept in encounter.reasonCode
+        for coding in concept.coding]
 
 
 def process_patient(db: DatabaseSession, patient: Patient) -> Any:

--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -314,7 +314,9 @@ def assert_required_resource_types_present(resources: Dict[str, List[DomainResou
     * There is at least one Patient or DiagnosticReport Resource
     * If there is a Patient, there is at least one Encounter
     * The number of Observation Resources equals or exceeds the total number
-      of Encounter or Patient Resources when there are Specimen Resources.
+      of Specimen Resources when there are Encounter Resources. (This is
+      required because Observation Resources are the only way to link Specimen
+      Resources to Encounter Resources.)
     """
     if not (resources['Patient'] or resources['DiagnosticReport']):
         raise SkipBundleError("Either a Patient or a DiagnosticReport Resource are required in a FHIR Bundle.")
@@ -322,16 +324,15 @@ def assert_required_resource_types_present(resources: Dict[str, List[DomainResou
     if resources['Patient'] and not resources['Encounter']:
         raise SkipBundleError("At least one Encounter Resource is required in a FHIR Bundle containing a Patient Resource")
 
-    if resources['Specimen']:
-        patients = len(resources['Patient'])
-        encounters = len(resources['Encounter'])
+    if resources['Specimen'] and resources['Encounter']:
+        specimens = len(resources['Specimen'])
         observations = len(resources['Observation'])
 
-        if not observations >= max([patients, encounters]):
+        if not observations >= specimens:
             raise SkipBundleError(
                 f"Expected the total number of Observation Resources ({observations}) "
-                f"to equal or exceed the total number of Patient or Encounter resources "
-                f"({patients} or {encounters}, respectively).")
+                f"to equal or exceed the total number of Specimen resources "
+                f"({specimens}) when Encounter resources are present.")
 
 
 def identifier(resource: DomainResource, system: str=None) -> Optional[str]:

--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -438,6 +438,11 @@ def process_encounter(db: DatabaseSession, encounter: Encounter,
 
     encounter_reason = process_encounter_reason(encounter)
 
+    part_of_identifier = None
+    if encounter.partOf:
+        part_of_encounter = encounter.partOf.resolved(Encounter)
+        part_of_identifier = identifier(part_of_encounter, f"{INTERNAL_SYSTEM}/encounter")
+
     # XXX FIXME: This shallow dictionary merge is buggy if there are
     # resources of the same type in both the related and contained sets.
     #   -trs, 19 Dec 2019
@@ -446,6 +451,8 @@ def process_encounter(db: DatabaseSession, encounter: Encounter,
         details['language'] = patient_language
     if encounter_reason:
         details['reason'] = encounter_reason
+    if part_of_identifier:
+        details['part_of'] = part_of_identifier
 
     return upsert_encounter(db,
         identifier      = identifier(encounter, f"{INTERNAL_SYSTEM}/encounter"),


### PR DESCRIPTION
Some updates to the FHIR ETL to allow ingestion of the SCAN follow-up encounter:
* Allow FHIR bundle to have multiple Encounter resources even if it only has one Specimen resource
* Ingest `Encounter.reasonCode` into `encounter.details.reason` to allow for differentiation of follow-up encounters from primary encounters. 