### PR TITLE
optimize REDCap DET ETL

### DIFF
--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -155,13 +155,12 @@ def command_for_project(name: str,
                     return
 
                 for redcap_record in redcap_records:
-                    record_id = redcap_record[project.record_id_field]
                     # XXX TODO: Handle records with repeating instruments or longitudinal
                     # events.
                     try:
-                        det = latest_complete_dets.pop(record_id)
+                        det = latest_complete_dets.pop(redcap_record.id)
                     except KeyError:
-                        LOG.warning(f"Found duplicate record id «{record_id}» in project {project.id}")
+                        LOG.warning(f"Found duplicate record id «{redcap_record.id}» in project {redcap_record.project.id}")
                         continue
 
                     with db.savepoint(f"redcap_det {det.id}"):

--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -129,7 +129,7 @@ def command_for_project(name: str,
                             LOG.debug(f"Skipping older REDCap DET {old_det.id}")
                             mark_skipped(db, old_det.id, etl_id)
 
-                        latest_complete_dets.update({record_id: det})
+                        latest_complete_dets[record_id] = det
 
                 # Batch request records from REDCap
                 project = get_redcap_project(redcap_url, project_id)

--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -131,6 +131,10 @@ def command_for_project(name: str,
 
                         latest_complete_dets[record_id] = det
 
+                if not latest_complete_dets:
+                    LOG.info("No new complete DETs found.")
+                    return
+
                 # Batch request records from REDCap
                 project = get_redcap_project(redcap_url, project_id)
                 record_ids = list(latest_complete_dets.keys())

--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -9,6 +9,7 @@ import click
 import logging
 from datetime import datetime, timezone
 from functools import wraps
+from textwrap import dedent
 from typing import Callable, Iterable, Optional, Tuple, Dict, List, Any
 from urllib.parse import urljoin
 from id3c.cli.command import with_database_session
@@ -160,7 +161,12 @@ def command_for_project(name: str,
                     try:
                         det = latest_complete_dets.pop(redcap_record.id)
                     except KeyError:
-                        LOG.warning(f"Found duplicate record id «{redcap_record.id}» in project {redcap_record.project.id}")
+                        LOG.warning(dedent(f"""
+                        Found duplicate record id «{redcap_record.id}» in project {redcap_record.project.id}.
+                        Duplicate record ids are commonly due to repeating instruments/longitudinal events in REDCap.
+                        If your REDCap project does not have repeating instruments or longitudinal events,
+                        then this may be caused by a bug in REDCap."""))
+
                         continue
 
                     with db.savepoint(f"redcap_det {det.id}"):


### PR DESCRIPTION
1. Aggregate DETs by record. Skip old DETs and only process the latest
complete DET for each record.

2. Make a batch request for records instead of requesting each record
individually from the REDCap API.

Note that this ETL still has the caveat of not being able to handle
records with repeating instruments or longitudinal events.