### PR TITLE
Materialized view refresher

### DIFF
--- a/lib/id3c/cli/command/__init__.py
+++ b/lib/id3c/cli/command/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "receiving",
     "geocode",
     "de_identify",
+    "refresh_materialized_view",
 ]
 
 

--- a/lib/id3c/cli/command/refresh_materialized_view.py
+++ b/lib/id3c/cli/command/refresh_materialized_view.py
@@ -28,7 +28,7 @@ def refresh_materialized_view(schema_name, view_name, db: DatabaseSession):
 
     LOG.info(f"Refreshing materialized view «{schema_name}.{view_name}»")
 
-    db.cursor("refresh materialized view").execute("""
+    db.cursor().execute("""
         select refresh_materialized_view(%s, %s)
     """, (schema_name, view_name ))
 

--- a/lib/id3c/cli/command/refresh_materialized_view.py
+++ b/lib/id3c/cli/command/refresh_materialized_view.py
@@ -1,0 +1,36 @@
+"""
+Refresh materialized view in ID3C.
+"""
+import click
+import logging
+from id3c.cli import cli
+from id3c.cli.command import with_database_session
+from id3c.db.session import DatabaseSession
+
+
+LOG = logging.getLogger(__name__)
+
+
+@cli.command("refresh-materialized-view")
+@with_database_session
+
+@click.argument("schema-name",
+    metavar = "<schema>",
+    nargs = 1)
+@click.argument("view-name",
+    metavar = "<view>",
+    nargs = 1)
+
+def refresh_materialized_view(schema_name, view_name, db: DatabaseSession):
+    """
+    Refresh materialized view <schema>.<view> in ID3C.
+    """
+
+    LOG.info(f"Refreshing materialized view «{schema_name}.{view_name}»")
+
+    db.cursor("refresh materialized view").execute("""
+        select refresh_materialized_view(%s, %s)
+    """, (schema_name, view_name ))
+
+    LOG.info("Successfully refreshed materialized view")
+

--- a/schema/deploy/roles/materialized-view-refresher/create.sql
+++ b/schema/deploy/roles/materialized-view-refresher/create.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:roles/materialized-view-refresher/create to pg
+
+begin;
+
+create role "materialized-view-refresher";
+
+comment on role "materialized-view-refresher" is
+    'For refreshing materialized views';
+
+commit;

--- a/schema/deploy/roles/materialized-view-refresher/grants.sql
+++ b/schema/deploy/roles/materialized-view-refresher/grants.sql
@@ -1,0 +1,43 @@
+-- Deploy seattleflu/schema:roles/materialized-view-refresher/grants to pg
+-- requires: roles/materialized-view-refresher/create
+
+begin;
+
+revoke all on database :"DBNAME" from "materialized-view-refresher";
+revoke all on schema receiving, warehouse, shipping from "materialized-view-refresher";
+revoke all on all tables in schema receiving, warehouse, shipping from "materialized-view-refresher";
+
+grant connect on database :"DBNAME" to "materialized-view-refresher";
+
+-- Regular users cannot refresh materialized views because only the view
+-- owner has permission to refresh them.
+-- Create a function that runs in the security context of its owner so that
+-- other users can refresh the view.
+create or replace function public.refresh_materialized_view(view_schema text, view_name text)
+    returns void
+    security definer
+    language plpgsql as $$
+        declare
+            message text;
+        begin
+            execute format('refresh materialized view concurrently %I.%I', view_schema, view_name);
+            raise info 'Refreshed materialized view %', view_name;
+            return;
+        exception when others then
+            get stacked diagnostics message = message_text;
+            raise exception 'ERROR: %', message;
+        end;
+    $$
+    volatile
+    parallel unsafe;
+
+revoke execute
+    on function public.refresh_materialized_view
+from public;
+
+grant execute
+    on function public.refresh_materialized_view
+    to "materialized-view-refresher";
+
+
+commit;

--- a/schema/revert/roles/materialized-view-refresher/create.sql
+++ b/schema/revert/roles/materialized-view-refresher/create.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:roles/materialized-view-refresher/create from pg
+
+begin;
+
+drop role "materialized-view-refresher";
+
+commit;

--- a/schema/revert/roles/materialized-view-refresher/grants.sql
+++ b/schema/revert/roles/materialized-view-refresher/grants.sql
@@ -1,0 +1,15 @@
+-- Revert seattleflu/schema:roles/materialized-view-refresher/grants from pg
+
+begin;
+
+revoke execute
+    on function public.refresh_materialized_view
+from "materialized-view-refresher";
+
+drop function public.refresh_materialized_view;
+
+revoke all on database :"DBNAME" from "materialized-view-refresher";
+revoke all on all tables in schema public from "materialized-view-refresher";
+revoke all on schema public from "materialized-view-refresher";
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -192,3 +192,6 @@ warehouse/primary-encounter-location [warehouse/encounter-location/relation-fk] 
 
 warehouse/sample/collection-date [warehouse/sample] 2020-04-20T18:49:35Z Jover Lee <joverlee@fredhutch.org> # Add collection-date to samples
 @2020-04-20 2020-04-20T19:47:27Z Jover Lee <joverlee@fredhutch.org> # Schema as of 20 April 2020
+
+roles/materialized-view-refresher/create 2020-05-18T18:52:40Z Jover Lee <joverlee@fredhutch.org> # Role for refreshing materialize-view-refresher
+roles/materialized-view-refresher/grants [roles/materialized-view-refresher/create] 2020-05-18T18:54:04Z Jover Lee <joverlee@fredhutch.org> # Grants to materialized-view-refresher

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -195,3 +195,4 @@ warehouse/sample/collection-date [warehouse/sample] 2020-04-20T18:49:35Z Jover L
 
 roles/materialized-view-refresher/create 2020-05-18T18:52:40Z Jover Lee <joverlee@fredhutch.org> # Role for refreshing materialize-view-refresher
 roles/materialized-view-refresher/grants [roles/materialized-view-refresher/create] 2020-05-18T18:54:04Z Jover Lee <joverlee@fredhutch.org> # Grants to materialized-view-refresher
+@2020-05-18 2020-05-18T19:44:24Z Jover Lee <joverlee@fredhutch.org> # Schema as of 18 May 2020

--- a/schema/verify/roles/materialized-view-refresher/create.sql
+++ b/schema/verify/roles/materialized-view-refresher/create.sql
@@ -1,0 +1,8 @@
+-- Verify seattleflu/schema:roles/materialized-view-refresher/create on pg
+
+begin;
+
+-- No real need to test that the user was created; the database would have
+-- thrown an error if it wasn't.
+
+rollback;

--- a/schema/verify/roles/materialized-view-refresher/grants.sql
+++ b/schema/verify/roles/materialized-view-refresher/grants.sql
@@ -1,0 +1,11 @@
+-- Verify seattleflu/schema:roles/materialized-view-refresher/grants on pg
+
+begin;
+
+select 1/pg_catalog.has_database_privilege('materialized-view-refresher', :'DBNAME', 'connect')::int;
+select 1/pg_catalog.has_schema_privilege('materialized-view-refresher', 'public', 'usage')::int;
+select 1/pg_catalog.has_function_privilege('materialized-view-refresher', 'public.refresh_materialized_view(text,text)', 'execute')::int;
+
+select 1/(not pg_catalog.has_function_privilege('public', 'public.refresh_materialized_view(text,text)', 'execute'))::int;
+
+rollback;


### PR DESCRIPTION
Add role and command to refresh materialized views.

Moved from id3c-customizations with @tsibley's suggestion:
>Hmm, and actually, what about building this into a core ID3C CLI command? It's something I expect will be not uncommon. (I'm actually really surprised it took us this long to need materialized views! I'd thought we'd hit a need for them much sooner.) I guess this would mean moving the materialized-view-refresher role to core, though, which is maybe more shuffling than we want to bother with right now…