### PR TITLE
etl fhir: ingest `effectiveDateTime` from Diagnostic Reports

### DIFF
--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -52,7 +52,7 @@ LOG = logging.getLogger(__name__)
 # this revision number should be incremented.
 # The etl name has been added to allow multiple etls to process the same
 # receiving table
-REVISION = 4
+REVISION = 5
 ETL_NAME = 'fhir'
 INTERNAL_SYSTEM = 'https://seattleflu.org'
 LOCATION_RELATION_SYSTEM = 'http://terminology.hl7.org/CodeSystem/v3-RoleCode'
@@ -904,6 +904,9 @@ def process_presence_absence_tests(db: DatabaseSession, report: DiagnosticReport
             continue
 
         details = { "device": observation.device.identifier.value }
+
+        if report.effectiveDateTime:
+            details["effective_datetime"] = report.effectiveDateTime.as_json()
 
         upsert_presence_absence(db,
             identifier = f'{barcode}/{snomed_code}/{observation.device.identifier.value}',


### PR DESCRIPTION
Ingests into `warehouse.presence_absence.details.effective_datetime`

This change was made due to a request from the self-test team to report the time at which the participants performed the self-test for Ellume.