### PR TITLE
Redcap det event

### DIFF
--- a/lib/id3c/cli/command/redcap_det.py
+++ b/lib/id3c/cli/command/redcap_det.py
@@ -39,7 +39,7 @@ def redcap_det():
            "Used as a sanity check that the correct API token is provided.",
     required = True)
 
-@click.option("--token-name",
+@click.option("--token",
     metavar = "<token-name>",
     help = "The name of the environment variable that holds the API token",
     default = "REDCAP_API_TOKEN")
@@ -55,7 +55,7 @@ def redcap_det():
            "Format must be YYYY-MM-DD HH:MM:SS (e.g. '2019-01-01 00:00:00')")
 
 @click.option("--instrument", "instruments",
-    metavar = "<name>",
+    metavar = "<instrument-name>",
     help = "Limit generated DET notifications to the named instrument; may be used multiple times",
     multiple = True)
 
@@ -64,7 +64,7 @@ def redcap_det():
     is_flag = True,
     flag_value = True)
 
-def generate(record_ids: List[str], project_id: int, token_name: str, since_date: str, until_date: str, instruments: List[str], include_incomplete: bool):
+def generate(record_ids: List[str], project_id: int, token: str, since_date: str, until_date: str, instruments: List[str], include_incomplete: bool):
     """
     Generate DET notifications for REDCap records.
 
@@ -74,7 +74,7 @@ def generate(record_ids: List[str], project_id: int, token_name: str, since_date
     of specific record ids with date filters, so this command does not either.
 
     Requires environmental variables REDCAP_API_URL and REDCAP_API_TOKEN (or
-    whatever you passed to --token-name).
+    whatever you passed to --token).
 
     DET notifications are output for all completed instruments for each record
     by default.  Pass --include-incomplete to output DET notifications for
@@ -84,7 +84,7 @@ def generate(record_ids: List[str], project_id: int, token_name: str, since_date
     All DET notifications are output to stdout as newline-delimited JSON
     records.  You will likely want to redirect stdout to a file.
     """
-    api_token = os.environ[token_name]
+    api_token = os.environ[token]
     api_url = os.environ['REDCAP_API_URL']
 
     project = Project(api_url, api_token, project_id)

--- a/lib/id3c/cli/command/redcap_det.py
+++ b/lib/id3c/cli/command/redcap_det.py
@@ -114,6 +114,10 @@ def generate(record_ids: List[str], project_id: int, token: str, since_date: str
 
     if events:
         LOG.debug(f"Producing DET notifications for the following events: {events}")
+        unknown_events = set(events) - set(project.events)
+
+        assert not unknown_events, \
+            f"The following --event names aren't in the REDCap project: {unknown_events}"
     else:
         LOG.debug(f"Producing DET notifications for all events ({project.events})")
         events = project.events
@@ -127,19 +131,14 @@ def generate(record_ids: List[str], project_id: int, token: str, since_date: str
 
     if instruments:
         LOG.debug(f"Producing DET notifications for the following {'instruments' if include_incomplete else 'complete instruments'}: {instruments}")
+        unknown_instruments = set(instruments) - set(project.instruments)
+
+        assert not unknown_instruments, \
+            f"The following --instrument names aren't in the REDCap project: {unknown_instruments}"
     else:
         LOG.debug(f"Producing DET notifications for all {'instruments' if include_incomplete else 'complete instruments'} ({project.instruments})")
         instruments = project.instruments
 
-    unknown_events = set(events) - set(project.events)
-
-    assert not unknown_events, \
-        f"The following --event names aren't in the REDCap project: {unknown_events}"
-
-    unknown_instruments = set(instruments) - set(project.instruments)
-
-    assert not unknown_instruments, \
-        f"The following --instrument names aren't in the REDCap project: {unknown_instruments}"
 
     for record in records:
         for instrument in instruments:

--- a/lib/id3c/cli/command/redcap_det.py
+++ b/lib/id3c/cli/command/redcap_det.py
@@ -142,6 +142,9 @@ def generate(record_ids: List[str], project_id: int, token: str, since_date: str
 
 def assert_known_attribute_value(project: Project, attribute: str, values: List[str], option: str=None):
     """
+    Throws an :class:`Exception` if the given REDCap *project* contains no
+    values for the given *attribute*.
+
     Throws an :class:`AssertionError` if any of the given *values* are not
     contained in the *attribute* of the given REDCap *project*.
 
@@ -149,7 +152,11 @@ def assert_known_attribute_value(project: Project, attribute: str, values: List[
     command option as presented to the user. If not provided, defaults to
     *attribute*.
     """
-    unknown_values = set(values) - set(getattr(project, attribute))
+    known_values = getattr(project, attribute)
+    if not known_values:
+        raise Exception(f"There are no --{option} values in the REDCap project.")
+
+    unknown_values = set(values) - set(known_values)
 
     if not option:
         option = attribute

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -138,6 +138,7 @@ class Project:
                 until_date: str = None,
                 ids: List[str] = None,
                 fields: List[str] = None,
+                events: List[str] = None,
                 raw: bool = False) -> List['Record']:
         """
         Fetch records for this REDCap project.
@@ -158,6 +159,9 @@ class Project:
 
         The optional *fields* parameter can be used to limit the fields
         returned for each record.
+
+        The optional *events* parameters can be used to limit the events (i.e.
+        arms) returned for each record.
 
         The optional *raw* parameter controls if numeric/coded values are
         returned for multiple choice fields.  When false (the default), string
@@ -183,6 +187,9 @@ class Project:
 
         if fields is not None:
             parameters['fields'] = ",".join(map(str, fields))
+
+        if events is not None:
+            parameters['events'] = ",".join(map(str, events))
 
         return [Record(self, r) for r in self._fetch("record", parameters)]
 

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -27,6 +27,7 @@ class Project:
     base_url: str
     _details: dict
     _instruments: List[str] = None
+    _events: List[str] = None
     _fields: List[dict] = None
     _redcap_version: str = None
 
@@ -67,6 +68,18 @@ class Project:
             self._instruments = list(map(nameof, self._fetch("instrument")))
 
         return self._instruments
+
+
+    @property
+    def events(self) -> List[str]:
+        """
+        Names of all events in this REDCap project.
+        """
+        if not self._events:
+            nameof = itemgetter("unique_event_name")
+            self._events = list(map(nameof, self._fetch("event")))
+
+        return self._events
 
 
     @property

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -75,9 +75,13 @@ class Project:
         """
         Names of all events in this REDCap project.
         """
-        if not self._events:
+        if self._events is None:
             nameof = itemgetter("unique_event_name")
-            self._events = list(map(nameof, self._fetch("event")))
+
+            if self._details["is_longitudinal"]:
+                self._events = list(map(nameof, self._fetch("event")))
+            else:
+                self._events = []
 
         return self._events
 

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -5,7 +5,7 @@ import logging
 import re
 import requests
 from enum import Enum
-from functools import lru_cache, wraps
+from functools import lru_cache
 from operator import itemgetter
 from typing import Any, Dict, List
 

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -39,7 +39,7 @@ class Project:
         # trailing 'api' from the API URL
         self.base_url = re.sub(r'api/?$', '', api_url)
 
-        # Sanity check project details
+        # Check if project details match our expectations
         self._details = self._fetch("project")
 
         assert self.id == project_id, \


### PR DESCRIPTION
Add an `--event` option to the REDCap DET generate command.
Add an `events` attribute to the REDCap `Project` class.

Do some minor reworking/refactoring of the generate command.