### PR TITLE
labelmaker: Add layout for collections-scan-kiosks

### DIFF
--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -198,6 +198,15 @@ class CollectionsScanLayout(LabelLayout):
     barcode_type = 'SCAN'
     copies_per_barcode = 2
     reference = "scanpublichealth.org"
+
+
+class CollectionsScanKiosksLayout(LabelLayout):
+    sku = "LCRY-1100"
+    barcode_type = 'SCAN - STAVE'
+    copies_per_barcode = 1
+    reference = "scanpublichealth.org"
+
+
 class CollectionsCliaComplianceLayout(LabelLayout):
     sku = "LCRY-1100"
     barcode_type = "CLIA"
@@ -221,6 +230,7 @@ class SamplesHaarviLayout(LabelLayout):
 LAYOUTS = {
     "samples": SamplesLayout,
     "collections-scan": CollectionsScanLayout,
+    "collections-scan-kiosks": CollectionsScanKiosksLayout,
     "collections-seattleflu.org": CollectionsSeattleFluLayout,
     "collections-kiosks": CollectionsKiosksLayout,
     "collections-kiosks-asymptomatic": CollectionsKiosksAsymptomaticLayout,


### PR DESCRIPTION
Labeled as `SCAN - STAVE` for surge testing around vulnerable/exposures.
Currently only needs barcode in singlet.

Barcode arrangements originally discussed on [slack](https://seattle-flu-study.slack.com/archives/CDCJPAW2E/p1594763447062000)

I ran the following to create the identifier set in the database:
```
pipenv run id3c identifier set create "collections-scan-kiosks" "Seattle Coronavirus Assessment Network kiosks for surge testing around vulnerable/exposures"
```