### PR TITLE
etl fhir: add new SCAN identifier set

### DIFF
--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -68,6 +68,7 @@ EXPECTED_COLLECTION_IDENTIFIER_SETS = [
     'collections-seattleflu.org',
     'collections-swab&send-asymptomatic',
     'collections-scan',
+    'collections-scan-kiosks',
 ]
 EXPECTED_SAMPLE_IDENTIFIER_SETS = ['samples']
 


### PR DESCRIPTION
Making this PR as a reminder that this change needs to be deployed along with https://github.com/seattleflu/id3c-customizations/pull/118.

Although there's also nothing stopping from this being deployed before 😄 