### PR TITLE
Ingest sample.collected date from FHIR Specimen collection

### DIFF
--- a/lib/id3c/cli/command/etl/manifest.py
+++ b/lib/id3c/cli/command/etl/manifest.py
@@ -208,7 +208,7 @@ def upsert_sample(db: DatabaseSession,
             update warehouse.sample
                set identifier = %(identifier)s,
                    collection_identifier = %(collection_identifier)s,
-                   collected = date_or_null(%(collection_date)s),
+                   collected = coalesce(date_or_null(%(collection_date)s), collected),
                    details = coalesce(details, '{}') || %(additional_details)s
 
              where sample_id = %(sample_id)s

--- a/lib/id3c/utils.py
+++ b/lib/id3c/utils.py
@@ -1,6 +1,8 @@
 """
 Utilities.
 """
+from typing import Any, Sequence, Union
+
 
 def format_doc(**kwargs):
     """
@@ -14,3 +16,46 @@ def format_doc(**kwargs):
         function.__doc__ = function.__doc__.format_map(kwargs)
         return function
     return wrap
+
+
+def getattrpath(value: Any, attrpath: Union[str, Sequence[str]]) -> Any:
+    """
+    Get a nested named attribute, described by *attrpath*, from the
+    object *value*, or return None if one of the attributes in the path
+    doesn't exist.
+
+    *attrpath* may be a dotted-string like ``a.b.c`` or a sequence
+    (list or tuple) like ``("a", "b", "c")``.
+
+    >>> class Namespace:
+    ...     def __init__(self):
+    ...         self.__dict__ = {}
+    ...     def __repr__(self):
+    ...         return repr(self.__dict__)
+
+    >>> obj = Namespace()
+    >>> obj.a = Namespace()
+    >>> obj.a.b = Namespace()
+    >>> obj.a.b.c = 42
+    >>> getattrpath(obj, "a")
+    {'b': {'c': 42}}
+    >>> getattrpath(obj, "a.b.c")
+    42
+    >>> getattrpath(obj, "a.b.x")
+    >>> getattrpath(obj, "a.x")
+    >>> getattrpath(obj, "x")
+    >>> getattrpath(obj, ("a", "b", "c"))
+    42
+    """
+    if isinstance(attrpath, str):
+        attrpath = attrpath.split(".")
+
+    assert len(attrpath) != 0
+
+    for attr in attrpath:
+        value = getattr(value, attr, None)
+
+        if value is None:
+            return None
+
+    return value


### PR DESCRIPTION
See commit messages for details on the functionality.

In particular, I'd like feedback on the update-if-not-null behaviour that both the manifest and FHIR ETLs now do for `warehouse.sample.collected`. I think it makes sense, but it does introduce an uncertainty about where the date comes, as for any given record it now depends on what ETL received data and processed it most recently. They _should_ both agree, but of course in practice there will probably be times when they don't.