### PR TITLE
Add barcode layout for season 3 househould arm

### DIFF
--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -226,6 +226,12 @@ class SamplesHaarviLayout(LabelLayout):
     copies_per_barcode = 1
     reference = "HAARVI"
 
+class CollectionsHouseholdGeneralLayout(LabelLayout):
+    sku = "LCRY-1100"
+    barcode_type = "HH GENERAL"
+    copies_per_barcode = 1
+    reference = "seattleflu.org"
+
 
 LAYOUTS = {
     "samples": SamplesLayout,
@@ -240,6 +246,7 @@ LAYOUTS = {
     "collections-household-observation-asymptomatic": CollectionsHouseholdObservationAsymptomaticLayout,
     "collections-household-intervention": CollectionsHouseholdInterventionLayout,
     "collections-household-intervention-asymptomatic": CollectionsHouseholdInterventionAsymptomaticLayout,
+    "collections-household-general": CollectionsHouseholdGeneralLayout,
     "collections-self-test": CollectionsSelfTestLayout,
     "collections-fluathome.org": CollectionsFluAtHomeLayout,
     "collections-clia-compliance": CollectionsCliaComplianceLayout,


### PR DESCRIPTION
This is a PR for a barcode layout to go with a new identifier set.
The identifier set has already been created. It's called collections-household-general-season-three (I put season three in the name to help [me] distinguish it from the 4 other household collection set identifiers.)

The request in Slack from Roni was:
"is it possible to get 115 sheets of orange Household barcodes? This is for the upcoming, general Household year 3 study."
"these are for this upcoming year's household study, which is no longer 'household observation' but just the household study. We only need single barcodes for this (printed just once) thanks!"
