### PR TITLE
labelmaker: Add layout for UW Reopening barcodes

### DIFF
--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -239,14 +239,14 @@ class CollectionsUWObservedLayout(LabelLayout):
     sku = "LCRY-1100"
     barcode_type = 'UW OBSERVED'
     copies_per_barcode = 1
-    reference = "washington.edu"
+    reference = "seattleflu.org"
 
 
 class CollectionsUWMailLayout(LabelLayout):
     sku = "LCRY-1100"
     barcode_type = 'UW MAIL'
     copies_per_barcode = 2
-    reference = "washington.edu"
+    reference = "seattleflu.org"
 
 
 LAYOUTS = {

--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -220,17 +220,33 @@ class CollectionsHaarviLayout(LabelLayout):
     copies_per_barcode = 1
     reference = "HAARVI"
 
+
 class SamplesHaarviLayout(LabelLayout):
     sku = "LCRY-2380"
     barcode_type = "SAMPLE"
     copies_per_barcode = 1
     reference = "HAARVI"
 
+
 class CollectionsHouseholdGeneralLayout(LabelLayout):
     sku = "LCRY-1100"
     barcode_type = "HH GENERAL"
     copies_per_barcode = 1
     reference = "seattleflu.org"
+
+
+class CollectionsUWObservedLayout(LabelLayout):
+    sku = "LCRY-1100"
+    barcode_type = 'UW OBSERVED'
+    copies_per_barcode = 1
+    reference = "washington.edu"
+
+
+class CollectionsUWMailLayout(LabelLayout):
+    sku = "LCRY-1100"
+    barcode_type = 'UW MAIL'
+    copies_per_barcode = 2
+    reference = "washington.edu"
 
 
 LAYOUTS = {
@@ -254,6 +270,8 @@ LAYOUTS = {
     "test-strips-fluathome.org": _TestStripsFluAtHomeLayout,
     "samples-haarvi": SamplesHaarviLayout,
     "collections-haarvi": CollectionsHaarviLayout,
+    'collections-uw-observed': CollectionsUWObservedLayout,
+    'collections-uw-mail': CollectionsUWMailLayout,
 }
 
 


### PR DESCRIPTION
Add two new layouts for the UW Reopening (a.k.a. Husky Coronavirus
Testing) study collection barcode sets.

- [ ] Update Barcodes documentation