### PR TITLE
etl redcap-det: Fetch records from REDCap in batches no larger than 5,000

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "fiona",
         "flask",
         "fsspec",
+        "more-itertools",
         "pandas >=1.0.1,<2",
         "psycopg2 >=2.8,<3",
         "pyyaml",


### PR DESCRIPTION
Alleviates presumed strain on the REDCap API in cases when we bump an ETL revision and refetch ~everything from a very large project (as just happened with the Husky Coronavirus Testing project, but could also happen with SCAN).

Batch size to fetch defaults to 5,000, but can be tuned at invocation using the new --fetch-batch-size option.  5,000 is a mostly arbitrary number.  It might not be the best value for any project and is certainly not the best value for all projects or servers.

All records are still fetched up-front and held in memory before the underlying ETL routine is called in a loop.  A future improvement would be to process each batch before fetching the next, but that requires partitioning the set of DETs too.

