### PR TITLE
Add event name and instance ID to REDCap Record

### DIFF
--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -7,7 +7,7 @@ import requests
 from enum import Enum
 from functools import lru_cache
 from operator import itemgetter
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 LOG = logging.getLogger(__name__)
@@ -257,11 +257,21 @@ class Record(dict):
     """
     project: Project
     id: str
+    event_name: Optional[str]
+    repeat_instance: Optional[int]
 
     def __init__(self, project: Project, data: Any = {}) -> None:
         super().__init__(data)
         self.project = project
         self.id = self[self.project.record_id_field]
+
+        # These field names are not variable across REDCap projects
+        self.event_name = self.get("redcap_event_name")
+
+        if self.get("redcap_repeat_instance"):
+            self.repeat_instance = int(self["redcap_repeat_instance"])
+        else:
+            self.repeat_instance = None
 
 
 class InstrumentStatus(Enum):

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -254,6 +254,11 @@ class Record(dict):
     Must be constructed with a REDCap :py:class:``Project``, which is stored as
     the ``project`` attribute and used to set the ``id`` attribute storing the
     record's primary id.
+
+    Note that event_name and repeat_instance might not be populated because their
+    corresponding fields (redcap_event_name and redcap_repeat_instance)
+    won't be returned by the API if the request includes the 'fields' parameter
+    but not the record_id field.
     """
     project: Project
     id: str

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -255,10 +255,10 @@ class Record(dict):
     the ``project`` attribute and used to set the ``id`` attribute storing the
     record's primary id.
 
-    Note that event_name and repeat_instance might not be populated because their
-    corresponding fields (redcap_event_name and redcap_repeat_instance)
-    won't be returned by the API if the request includes the 'fields' parameter
-    but not the record_id field.
+    Note that the ``event_name`` and ``repeat_instance`` attributes might not
+    be populated because their corresponding fields (``redcap_event_name`` and
+    ``redcap_repeat_instance``) won't be returned by the API if the request
+    includes the ``fields`` parameter but not the primary record id field.
     """
     project: Project
     id: str


### PR DESCRIPTION
This short change adds event name and repeat instance ID to the REDCap Record object.
I haven't seen anything that indicates that the field names for these vary across projects, so I did not make the field names project attributes like we do for record_id.