### PR TITLE
Childcare identifier

### DIFF
--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -76,6 +76,7 @@ EXPECTED_COLLECTION_IDENTIFIER_SETS = [
     'collections-uw-home',
     'collections-uw-observed',
     'collections-household-general',
+    'collections-childcare',
 ]
 EXPECTED_SAMPLE_IDENTIFIER_SETS = ['samples']
 

--- a/lib/id3c/cli/command/etl/manifest.py
+++ b/lib/id3c/cli/command/etl/manifest.py
@@ -76,6 +76,7 @@ def etl_manifest(*, db: DatabaseSession):
             "collections-uw-home",
             "collections-uw-observed",
             "collections-household-general",
+            "collections-childcare",
         },
         "rdt": {"collections-fluathome.org"}
     }


### PR DESCRIPTION
Add `collections-childcare` identifier set to the manifest and FHIR ETLs.