### PR TITLE
Configurable cache

### DIFF
--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -19,7 +19,7 @@ from id3c.cli.command import with_database_session
 from id3c.cli.redcap import is_complete, Project
 from id3c.db.session import DatabaseSession
 from id3c.db.datatypes import as_json, Json
-from id3c.cli.command.geocode import pickled_cache
+from id3c.cli.command import pickled_cache
 from . import etl
 
 

--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -26,18 +26,6 @@ from . import etl
 LOG = logging.getLogger(__name__)
 
 
-# XXX FIXME: I don't think we should hardcode a cache name like this,
-# particularly with a name that doesn't give any hint as to what uses it or
-# what it contains. The `id3c geocode` command, for instance, explicitly
-# parameterizes the cache file as an option.
-#
-# Going a step further, I don't think @command_for_project should even be
-# providing the "cache" parameter.  What is cached and where it is stored is
-# something specific to each REDCap DET routine, not a global invariant.
-#   -trs, 19 Dec 2019
-CACHE_FILE = 'cache.pickle'
-
-
 @etl.group("redcap-det", help = __doc__)
 def redcap_det():
     pass
@@ -108,11 +96,21 @@ def command_for_project(name: str,
             help        = "Write the output FHIR documents to stdout. You will likely want to redirect this to a file",
             default     = False)
 
+        # XXX FIXME: I don't think @command_for_project should even be
+        # providing the "cache" parameter.  What is cached and where it is stored is
+        # something specific to each REDCap DET routine, not a global invariant.
+        #   -trs, 19 Dec 2019
+        @click.option("--geocoding-cache",
+            metavar = "<cache.pickle>",
+            help = "Local file for caching the results of address geocoding. Geocoding lookups will not be cached otherwise.",
+            required = False,
+            type = click.Path(dir_okay=False, writable=True))
+
         @redcap_det.command(name, **kwargs)
         @with_database_session
         @wraps(routine)
 
-        def decorated(*args, db: DatabaseSession, log_output: bool, det_limit: int = None, redcap_api_batch_size: int, **kwargs):
+        def decorated(*args, db: DatabaseSession, log_output: bool, det_limit: int = None, redcap_api_batch_size: int, geocoding_cache: str = None, **kwargs):
             LOG.debug(f"Starting the REDCap DET ETL routine {name}, revision {revision}")
 
             # If the correct environment variables aren't defined, this will
@@ -204,7 +202,7 @@ def command_for_project(name: str,
                         redcap_records[record.id].append(record)
 
             # Process all DETs in order of redcap_det_id
-            with pickled_cache(CACHE_FILE) as cache:
+            with pickled_cache(geocoding_cache) as cache:
                 for det in all_dets:
                     with db.savepoint(f"redcap_det {det['id']}"):
                         LOG.info(f"Processing REDCap DET {det['id']}")

--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -102,6 +102,7 @@ def command_for_project(name: str,
         #   -trs, 19 Dec 2019
         @click.option("--geocoding-cache",
             metavar = "<cache.pickle>",
+            envvar = "GEOCODING_CACHE",
             help = "Local file for caching the results of address geocoding. Geocoding lookups will not be cached otherwise.",
             required = False,
             type = click.Path(dir_okay=False, writable=True))

--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -214,7 +214,7 @@ def get_geocoded_addresses(*,
          addresses_df['lng'],
          addresses_df['canonicalized_address']) = zip(
              *addresses_df['std_address'].apply(
-                 lambda row: get_response_from_cache_or_geocoding(row, cache)))
+                 lambda row: get_geocoded_address(row, cache)))
 
     return addresses_df
 
@@ -246,7 +246,7 @@ def standardize_address(address_series: pd.Series,
 
 
 
-def get_response_from_cache_or_geocoding(address: dict,
+def get_geocoded_address(address: dict,
                                          cache: TTLCache) -> Tuple[Any, Any, Any]:
     """
     Provided an *address* dict in a format that SmartyStreets US Address API

--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -31,10 +31,10 @@ from smartystreets_python_sdk import StaticCredentials, ClientBuilder
 from smartystreets_python_sdk.us_street import Lookup
 from smartystreets_python_sdk.us_extract import Lookup as ExtractLookup
 from id3c.cli import cli
+from id3c.cli.command import pickled_cache
 from id3c.cli.io.pandas import (
     load_file_as_dataframe
 )
-from id3c.cli.command import pickled_cache
 
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
Here are some commits I did awhile ago as part of a bigger picture to lock the cache file within python (instead of relying on a user to create file lock on the cache at runtime).

These commits alone may be enough to ease up on some of the constraint on our system -- that is, by using different caches for different ETL jobs, we can allow some jobs to run concurrently. 