### PR TITLE
Retrieve only etag detail from Google docs

### DIFF
--- a/lib/id3c/cli/command/manifest.py
+++ b/lib/id3c/cli/command/manifest.py
@@ -283,8 +283,8 @@ def _parse(*,
         LOG.debug(f"Reading Google Sheets document «{workbook}»")
         with export_file_from_google_drive(google_docs_document_id, GoogleDriveExportFormat.EXCEL) as file:
             workbook_bytes = file.read()
-        document_details = get_document_details(google_docs_document_id)
-        digest = sha1(document_details['etag'].encode()).hexdigest()
+        etag = get_document_etag(google_docs_document_id)
+        digest = sha1(etag.encode()).hexdigest()
 
     else:
         LOG.debug(f"Reading Excel workbook «{workbook}»")

--- a/lib/id3c/cli/io/google.py
+++ b/lib/id3c/cli/io/google.py
@@ -82,14 +82,11 @@ def extract_document_id_from_google_url(url_str: str) -> Optional[str]:
 
     return google_docs_matches["document_id"] if google_docs_matches else None
 
-def get_document_details(document_id: str) -> dict:
+def get_document_etag(document_id: str) -> str:
     """
-    Returns a set of metadata details about a Google Drive document.
+    Returns the etag of a Google Drive document.
     """
     drive_service = discovery.build("drive", "v2")
     metadata = drive_service.files().get(fileId=document_id).execute()
 
-    details = {'version': metadata.get('version'), 'etag': metadata.get('etag'), 'modified_date': metadata.get('modifiedDate'),
-        'modifiying_user': metadata.get('lastModifyingUserName')}
-
-    return details
+    return metadata["etag"]


### PR DESCRIPTION
The previous commit fixed how various metadata properties of a
Google doc are grabbed. Instead, just grab the etag since that's
all that's currently being used.