### PR TITLE
Pin smartystreets-python-sdk at 4.6.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "pyyaml",
         "requests",
         "s3fs",
-        "smartystreets-python-sdk >= 4.0.1",
+        "smartystreets-python-sdk >= 4.0.1, <= 4.6.1",
         "xlrd",
 
         # We use pkg_resources, which (confusingly) is provided by setuptools.


### PR DESCRIPTION
With 4.7.0 deployed we get this error:
"No module named 'smartystreets_python_sdk.us_reverse_geo"

I was able to run the uw-reopening ETL locally with this version pinned. The lat/log lookup succeeded.