### PR TITLE
Receiving indexes

### DIFF
--- a/schema/deploy/receiving/clinical/indexes/processing-log.sql
+++ b/schema/deploy/receiving/clinical/indexes/processing-log.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:receiving/clinical/indexes/processing-log to pg
+-- requires: receiving/clinical
+
+begin;
+
+create index clinical_processing_log_idx
+  on receiving.clinical
+  using gin (processing_log jsonb_path_ops);
+
+commit;

--- a/schema/deploy/receiving/consensus-genome/indexes/processing-log.sql
+++ b/schema/deploy/receiving/consensus-genome/indexes/processing-log.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:receiving/consensus-genome/indexes/processing-log to pg
+-- requires: receiving/consensus-genome
+
+begin;
+
+create index consensus_genome_processing_log_idx
+  on receiving.consensus_genome
+  using gin (processing_log jsonb_path_ops);
+
+commit;

--- a/schema/deploy/receiving/fhir/indexes/processing-log.sql
+++ b/schema/deploy/receiving/fhir/indexes/processing-log.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:receiving/fhir/indexes/processing-log to pg
+-- requires: receiving/fhir
+
+begin;
+
+create index fhir_processing_log_idx
+  on receiving.fhir
+  using gin (processing_log jsonb_path_ops);
+
+commit;

--- a/schema/deploy/receiving/longitudinal/indexes/processing-log.sql
+++ b/schema/deploy/receiving/longitudinal/indexes/processing-log.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:receiving/longitudinal/indexes/processing-log to pg
+-- requires: receiving/longitudinal
+
+begin;
+
+create index longitudinal_processing_log_idx
+  on receiving.longitudinal
+  using gin (processing_log jsonb_path_ops);
+
+commit;

--- a/schema/deploy/receiving/manifest/indexes/processing-log.sql
+++ b/schema/deploy/receiving/manifest/indexes/processing-log.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:receiving/manifest/indexes/processing-log to pg
+-- requires: receiving/manifest
+
+begin;
+
+create index manifest_processing_log_idx
+  on receiving.manifest
+  using gin (processing_log jsonb_path_ops);
+
+commit;

--- a/schema/deploy/receiving/presence-absence/indexes/processing-log.sql
+++ b/schema/deploy/receiving/presence-absence/indexes/processing-log.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:receiving/presence-absence/indexes/processing-log to pg
+-- requires: receiving/presence-absence
+
+begin;
+
+create index presence_absence_processing_log_idx
+  on receiving.presence_absence
+  using gin (processing_log jsonb_path_ops);
+
+commit;

--- a/schema/deploy/receiving/redcap-det/indexes/document-as-jsonb.sql
+++ b/schema/deploy/receiving/redcap-det/indexes/document-as-jsonb.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:receiving/redcap-det/indexes/document-as-jsonb to pg
+-- requires: receiving/redcap-det
+
+begin;
+
+create index redcap_det_document_as_jsonb_idx
+  on receiving.redcap_det
+  using gin ((document::jsonb) jsonb_path_ops);
+
+commit;

--- a/schema/deploy/receiving/redcap-det/indexes/processing-log.sql
+++ b/schema/deploy/receiving/redcap-det/indexes/processing-log.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:receiving/redcap-det/indexes/processing-log to pg
+-- requires: receiving/redcap-det
+
+begin;
+
+create index redcap_det_processing_log_idx
+  on receiving.redcap_det
+  using gin (processing_log jsonb_path_ops);
+
+commit;

--- a/schema/deploy/receiving/sequence-read-set/indexes/processing-log.sql
+++ b/schema/deploy/receiving/sequence-read-set/indexes/processing-log.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:receiving/sequence-read-set/indexes/processing-log to pg
+-- requires: receiving/sequence-read-set
+
+begin;
+
+create index sequence_read_set_processing_log_idx
+  on receiving.sequence_read_set
+  using gin (processing_log jsonb_path_ops);
+
+commit;

--- a/schema/revert/receiving/clinical/indexes/processing-log.sql
+++ b/schema/revert/receiving/clinical/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:receiving/clinical/indexes/processing-log from pg
+
+begin;
+
+drop index receiving.clinical_processing_log_idx;
+
+commit;

--- a/schema/revert/receiving/consensus-genome/indexes/processing-log.sql
+++ b/schema/revert/receiving/consensus-genome/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:receiving/consensus-genome/indexes/processing-log from pg
+
+begin;
+
+drop index receiving.consensus_genome_processing_log_idx;
+
+commit;

--- a/schema/revert/receiving/fhir/indexes/processing-log.sql
+++ b/schema/revert/receiving/fhir/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:receiving/fhir/indexes/processing-log from pg
+
+begin;
+
+drop index receiving.fhir_processing_log_idx;
+
+commit;

--- a/schema/revert/receiving/longitudinal/indexes/processing-log.sql
+++ b/schema/revert/receiving/longitudinal/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:receiving/longitudinal/indexes/processing-log from pg
+
+begin;
+
+drop index receiving.longitudinal_processing_log_idx;
+
+commit;

--- a/schema/revert/receiving/manifest/indexes/processing-log.sql
+++ b/schema/revert/receiving/manifest/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:receiving/manifest/indexes/processing-log from pg
+
+begin;
+
+drop index receiving.manifest_processing_log_idx;
+
+commit;

--- a/schema/revert/receiving/presence-absence/indexes/processing-log.sql
+++ b/schema/revert/receiving/presence-absence/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:receiving/presence-absence/indexes/processing-log from pg
+
+begin;
+
+drop index receiving.presence_absence_processing_log_idx;
+
+commit;

--- a/schema/revert/receiving/redcap-det/indexes/document-as-jsonb.sql
+++ b/schema/revert/receiving/redcap-det/indexes/document-as-jsonb.sql
@@ -1,0 +1,8 @@
+-- Revert seattleflu/schema:receiving/redcap-det/indexes/document-as-jsonb from pg
+-- requires: receiving/redcap-det
+
+begin;
+
+drop index receiving.redcap_det_document_as_jsonb_idx;
+
+commit;

--- a/schema/revert/receiving/redcap-det/indexes/processing-log.sql
+++ b/schema/revert/receiving/redcap-det/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:receiving/redcap-det/indexes/processing-log from pg
+
+begin;
+
+drop index receiving.redcap_det_processing_log_idx;
+
+commit;

--- a/schema/revert/receiving/sequence-read-set/indexes/processing-log.sql
+++ b/schema/revert/receiving/sequence-read-set/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:receiving/sequence-read-set/indexes/processing-log from pg
+
+begin;
+
+drop index receiving.sequence_read_set_processing_log_idx;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -203,3 +203,5 @@ shipping/age-bin-decade [shipping/schema types/intervalrange] 2020-08-12T22:33:5
 functions/hamming_distance [functions/hamming_distance@2020-08-12] 2020-11-12T00:44:39Z Thomas Sibley <tsibley@fredhutch.org> # Rework to add short-circuiting versions
 warehouse/identifier/triggers/barcode-distance-check [warehouse/identifier/triggers/barcode-distance-check@2020-08-12 functions/hamming_distance] 2020-11-12T00:12:11Z Thomas Sibley <tsibley@fredhutch.org> # Rework to make optimizations
 @2020-11-13 2020-11-13T21:21:55Z Thomas Sibley <tsibley@fredhutch.org> # Schema as of 13 Nov 2020
+
+receiving/redcap-det/indexes/document-as-jsonb [receiving/redcap-det] 2020-11-16T20:20:49Z Thomas Sibley <tsibley@fredhutch.org> # Index receiving.redcap_det.document::jsonb for REDCap DET ETL

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -205,3 +205,11 @@ warehouse/identifier/triggers/barcode-distance-check [warehouse/identifier/trigg
 @2020-11-13 2020-11-13T21:21:55Z Thomas Sibley <tsibley@fredhutch.org> # Schema as of 13 Nov 2020
 
 receiving/redcap-det/indexes/document-as-jsonb [receiving/redcap-det] 2020-11-16T20:20:49Z Thomas Sibley <tsibley@fredhutch.org> # Index receiving.redcap_det.document::jsonb for REDCap DET ETL
+receiving/clinical/indexes/processing-log [receiving/clinical] 2020-11-16T20:54:23Z Thomas Sibley <tsibley@fredhutch.org> # Index receiving.clinical.processing_log column
+receiving/consensus-genome/indexes/processing-log [receiving/consensus-genome] 2020-11-16T20:54:26Z Thomas Sibley <tsibley@fredhutch.org> # Index receiving.consensus_genome.processing_log column
+receiving/fhir/indexes/processing-log [receiving/fhir] 2020-11-16T20:54:28Z Thomas Sibley <tsibley@fredhutch.org> # Index receiving.fhir.processing_log column
+receiving/longitudinal/indexes/processing-log [receiving/longitudinal] 2020-11-16T20:54:31Z Thomas Sibley <tsibley@fredhutch.org> # Index receiving.longitudinal.processing_log column
+receiving/manifest/indexes/processing-log [receiving/manifest] 2020-11-16T20:54:33Z Thomas Sibley <tsibley@fredhutch.org> # Index receiving.manifest.processing_log column
+receiving/presence-absence/indexes/processing-log [receiving/presence-absence] 2020-11-16T20:54:36Z Thomas Sibley <tsibley@fredhutch.org> # Index receiving.presence_absence.processing_log column
+receiving/redcap-det/indexes/processing-log [receiving/redcap-det] 2020-11-16T20:54:38Z Thomas Sibley <tsibley@fredhutch.org> # Index receiving.redcap_det.processing_log column
+receiving/sequence-read-set/indexes/processing-log [receiving/sequence-read-set] 2020-11-16T20:54:41Z Thomas Sibley <tsibley@fredhutch.org> # Index receiving.sequence_read_set.processing_log column

--- a/schema/verify/receiving/clinical/indexes/processing-log.sql
+++ b/schema/verify/receiving/clinical/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:receiving/clinical/indexes/processing-log on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/receiving/consensus-genome/indexes/processing-log.sql
+++ b/schema/verify/receiving/consensus-genome/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:receiving/consensus-genome/indexes/processing-log on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/receiving/fhir/indexes/processing-log.sql
+++ b/schema/verify/receiving/fhir/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:receiving/fhir/indexes/processing-log on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/receiving/longitudinal/indexes/processing-log.sql
+++ b/schema/verify/receiving/longitudinal/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:receiving/longitudinal/indexes/processing-log on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/receiving/manifest/indexes/processing-log.sql
+++ b/schema/verify/receiving/manifest/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:receiving/manifest/indexes/processing-log on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/receiving/presence-absence/indexes/processing-log.sql
+++ b/schema/verify/receiving/presence-absence/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:receiving/presence-absence/indexes/processing-log on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/receiving/redcap-det/indexes/document-as-jsonb.sql
+++ b/schema/verify/receiving/redcap-det/indexes/document-as-jsonb.sql
@@ -1,0 +1,8 @@
+-- Verify seattleflu/schema:receiving/redcap-det/indexes/document-as-jsonb on pg
+-- requires: receiving/redcap-det
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/receiving/redcap-det/indexes/processing-log.sql
+++ b/schema/verify/receiving/redcap-det/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:receiving/redcap-det/indexes/processing-log on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/receiving/sequence-read-set/indexes/processing-log.sql
+++ b/schema/verify/receiving/sequence-read-set/indexes/processing-log.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:receiving/sequence-read-set/indexes/processing-log on pg
+
+begin;
+
+
+
+rollback;


### PR DESCRIPTION
See commit messages for all the deets.

After deploy, the following should be manually run to clean up my rogue index:

```
drop index receiving.redcap_det_document_jsonb_idx__trs_20200323;
```