### PR TITLE
api: Explicitly close DatabaseSession at request end

### DIFF
--- a/lib/id3c/api/utils/routes.py
+++ b/lib/id3c/api/utils/routes.py
@@ -34,7 +34,10 @@ def authenticated_datastore_session_required(route):
             username = auth.username,
             password = auth.password)
 
-        return route(*args, **kwargs, session = session)
+        try:
+            return route(*args, **kwargs, session = session)
+        finally:
+            session.close()
 
     return wrapped_route
 

--- a/lib/id3c/db/session.py
+++ b/lib/id3c/db/session.py
@@ -85,6 +85,11 @@ class DatabaseSession:
         """Proxy for the underlying connection's ``rollback`` method."""
         return self.connection.rollback
 
+    @property
+    def close(self):
+        """Proxy for the underlying connection's ``close`` method."""
+        return self.connection.close
+
 
     @contextmanager
     def savepoint(self, name: str = None) -> Iterator:


### PR DESCRIPTION
During local testing, I noticed that connections were held open
even after requests.

Based on inspecting the reference count of "session" after calling
"route", this does *not* appear to be a case of a circular reference
causing the session/connection to never reach a reference count of zero
and thus never be destroyed.

I suspect it happens because object destruction (__del__) does not
always happen immediately upon the reference count reaching zero (and
sometimes does not happen at all).

In any case, explicitly closing connections when you're finished is best
practice anyway.  This makes it clear that the session is not (and
should not be) used afterwards and immediately frees the related
database server resources.

It doesn't appear that the lingering connections occur in production,
which suggests to me that delayed destruction is more likely to happen
under the development server.  In production, any lingering connections
would also be cleaned up by our idle session terminator (but only after
enough time had passed).