### PR TITLE
etl presence-absence: skip samples that have been marked as failed

### DIFF
--- a/lib/id3c/cli/command/etl/presence_absence.py
+++ b/lib/id3c/cli/command/etl/presence_absence.py
@@ -102,6 +102,12 @@ def etl_presence_absence(*, db: DatabaseSession):
                     LOG.info(f"Skipping sample «{received_sample['sampleId']}» without SFS barcode")
                     continue
 
+                # Don't go any further if the sample is marked as Failed
+                sample_failed = received_sample.get("sampleFailed")
+                if sample_failed is True:
+                    LOG.info(f"Skipping sample «{received_sample_barcode}» that has been failed")
+                    continue
+
                 # Don't go any further if there are no results to import.
                 test_results = received_sample["targetResults"]
 


### PR DESCRIPTION
Each sample has a top level key "sampleFailed" that is marked True if
the entire sample has been marked as failed. We need to inspect this
top level key because the individual target results do not reflect this
failure status.

ID3C currently does not model failed presence/absence results,
so skip all results if the sample is failed at this top level.