### PR TITLE
Add exportSurveyFields parameter when fetching records

### DIFF
--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -201,6 +201,7 @@ class Project:
             'type': 'flat',
             'rawOrLabel': 'raw' if raw else 'label',
             'exportCheckboxLabel': 'true', # ignored by API if rawOrLabel == raw
+            'exportSurveyFields': 'true', # pulls the _identifier and _timestamp fields from surveys
         }
 
         assert not ((since_date or until_date) and ids), \


### PR DESCRIPTION
Set the exportSurveyFields parameter to true when fetching records
from REDCap so that for surveys, the {survey_name}_identifier and
{survey_name}_timestamp fields are returned.