### PR TITLE
REDCap DET generation

### DIFF
--- a/lib/id3c/cli/command/redcap_det.py
+++ b/lib/id3c/cli/command/redcap_det.py
@@ -32,17 +32,26 @@ def redcap_det():
 @redcap_det.command("generate")
 @click.argument("record-ids", nargs = -1)
 
+@click.option("--api-url",
+    metavar = "<url>",
+    help = "The API endpoint of the REDCap instance.",
+    required = True,
+    envvar = "REDCAP_API_URL",
+    show_envvar = True)
+
 @click.option("--project-id",
     metavar = "<id>",
     type = int,
     help = "The project id from which to fetch records.  "
-           "Used as a sanity check that the correct API token is provided.",
-    required = True)
+           "Must match the project associated with the provided API token.",
+    required = True,
+    envvar = "REDCAP_PROJECT_ID",
+    show_envvar = True)
 
 @click.option("--token",
     metavar = "<token-name>",
-    help = "The name of the environment variable that holds the API token",
-    default = "REDCAP_API_TOKEN")
+    help = "The name of the environment variable that holds the API token.  "
+           "Defaults to a name based on the --api-url and --project-id values: REDCAP_API_TOKEN_{api_url_origin}_{project_id}.")
 
 @click.option("--since-date",
     metavar = "<since-date>",
@@ -69,7 +78,7 @@ def redcap_det():
     is_flag = True,
     flag_value = True)
 
-def generate(record_ids: List[str], project_id: int, token: str, since_date: str, until_date: str,
+def generate(record_ids: List[str], api_url: str, project_id: int, token: str, since_date: str, until_date: str,
     instruments: List[str], events: List[str], include_incomplete: bool):
     """
     Generate DET notifications for REDCap records.
@@ -78,9 +87,6 @@ def generate(record_ids: List[str], project_id: int, token: str, since_date: str
     record ids are given, then all records (or all records matching the date
     filters) are considered.  The REDCap API does not support combining a list
     of specific record ids with date filters, so this command does not either.
-
-    Requires environmental variables REDCAP_API_URL and REDCAP_API_TOKEN (or
-    whatever you passed to --token).
 
     DET notifications are output for all completed instruments for each record
     by default.  Pass --include-incomplete to output DET notifications for
@@ -91,8 +97,7 @@ def generate(record_ids: List[str], project_id: int, token: str, since_date: str
     All DET notifications are output to stdout as newline-delimited JSON
     records.  You will likely want to redirect stdout to a file.
     """
-    api_token = os.environ[token]
-    api_url = os.environ['REDCAP_API_URL']
+    api_token = os.environ[token] if token else None
 
     project = Project(api_url, project_id, token = api_token)
 

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -405,7 +405,7 @@ def is_complete(instrument: str, data: dict) -> bool:
     >>> is_complete("test", {}) is None
     True
     """
-    instrument_complete_field = data.get(f"{instrument}_complete")
+    instrument_complete_field = data.get(completion_status_field(instrument))
 
     if instrument_complete_field is None:
         return None
@@ -415,6 +415,28 @@ def is_complete(instrument: str, data: dict) -> bool:
         InstrumentStatus.Complete.value,
         str(InstrumentStatus.Complete.value)
     }
+
+
+def completion_status_field(instrument: str) -> str:
+    """
+    Returns the REDCap automatic field name for the completion status of
+    *instrument*.
+
+    If want to know the completion status itself, use :func:`is_complete`
+    instead.
+    """
+    # XXX TODO: It would be good to normalize *instrument* here, including:
+    #
+    #   - Lowercasing
+    #   - Replacing runs of whitespace and/or non-alphanumerics (?) with a
+    #     single underscore.
+    #   - Maybe: removing leading numbers?
+    #
+    # The full set of transformations REDCap applies aren't entirely clear to
+    # me at the moment, so I'm punting for now.  The caller must provide the
+    # internal names.
+    #   -trs, 8 Jan 2020
+    return f"{instrument}_complete"
 
 
 def api_token(url: str, project_id: int) -> str:
@@ -541,7 +563,7 @@ def det(project: Project, record: dict, instrument: str, generated_by: str = Non
         'redcap_repeat_instrument',
     }
     """
-    instrument_complete = instrument + '_complete'
+    instrument_complete = completion_status_field(instrument)
 
     if not generated_by:
         generated_by = running_command_name()

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -162,6 +162,7 @@ class Project:
                 since_date: str = None,
                 until_date: str = None,
                 ids: List[str] = None,
+                instruments: List[str] = None,
                 fields: List[str] = None,
                 events: List[str] = None,
                 filter: str = None,
@@ -182,6 +183,9 @@ class Project:
 
         The optional *ids* parameter can be used to limit results to the given
         record ids.
+
+        The optional *instruments* parameter can be used to limit the
+        instruments ("forms") returned for each record.
 
         The optional *fields* parameter can be used to limit the fields
         returned for each record.
@@ -214,6 +218,9 @@ class Project:
 
         if ids is not None:
             parameters['records'] = ",".join(map(str, ids))
+
+        if instruments is not None:
+            parameters['forms'] = ",".join(map(str, instruments))
 
         if fields is not None:
             parameters['fields'] = ",".join(map(str, fields))


### PR DESCRIPTION
Switches `id3c redcap-det generate` to use the new-style env vars for API credentials and significantly reduces the amount of data transferred over the wire in the API requests.

See commit messages for details.