### PR TITLE
Redcap dal

### DIFF
--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -413,6 +413,13 @@ class Project:
         return updated_count
 
 
+    def users(self) -> List[Dict[str, Any]]:
+        """
+        Fetch the REDCap project's users.
+        """
+        return self._fetch('user', {})
+
+
     def _fetch(self, content: str, parameters: Dict[str, str] = {}, *, format: str = "json") -> Any:
         """
         Fetch REDCap *content* with a POST request to the REDCap API.

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -344,6 +344,24 @@ class Project:
         return updated_count
 
 
+    def report(self, report_id: str, raw: bool = False) -> List[Dict[str, Any]]:
+        """
+        Fetch the REDCap report *report_id* with all its fields.
+
+        The optional *raw* parameter controls if numeric/coded values are
+        returned for multiple choice fields.  When false (the default),
+        string labels are returned.
+        """
+        parameters = {
+            'type': 'flat',
+            'report_id': report_id,
+            'rawOrLabel': 'raw' if raw else 'label',
+            'exportCheckboxLabel': 'true', # ignored by API if rawOrLabel == raw
+        }
+
+        return self._fetch('report', parameters)
+
+
     def _fetch(self, content: str, parameters: Dict[str, str] = {}, *, format: str = "json") -> Any:
         """
         Fetch REDCap *content* with a POST request to the REDCap API.

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -362,6 +362,13 @@ class Project:
         return self._fetch('report', parameters)
 
 
+    def metadata(self) -> List[Dict[str, str]]:
+        """
+        Fetch the REDCap project metadata.
+        """
+        return self._fetch('metadata', {})
+
+
     def _fetch(self, content: str, parameters: Dict[str, str] = {}, *, format: str = "json") -> Any:
         """
         Fetch REDCap *content* with a POST request to the REDCap API.


### PR DESCRIPTION
Add additional methods to our redcap `Project` class to support different functionality we use in the [backoffice](https://github.com/seattleflu/backoffice) repo.

Methods include
* report
* metadata
* update_metadata
* users
* update_users