### PR TITLE
redcap: Mask data being send to the REDCap API when logging request parameters

### DIFF
--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -350,7 +350,12 @@ class Project:
         Consult REDCap API documentation for required and optional parameters
         to include in API request.
         """
-        LOG.debug(f"Requesting content={content} from REDCap with params {parameters}")
+        loggable_parameters = parameters.copy()
+
+        if "data" in loggable_parameters:
+            loggable_parameters["data"] = "***MASKED***"
+
+        LOG.debug(f"Requesting content={content} from REDCap with params {loggable_parameters}")
 
         headers = {
             'Content-type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
Several of REDCap's API methods take a "data" parameter to upload
record or user information.  We don't want to include this in logs due
to privacy/PII concerns as well as exceeding syslog message sizes.

Masking is the same approach we take in id3c.db.session.pg_environment().