### PR TITLE
Update labelmaker with school testing labels

### DIFF
--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -278,10 +278,17 @@ class CollectionsChildcareLayout(LabelLayout):
     reference = "seattleflu.org"
 
 
-class CollectionsSchoolTestingLayout(LabelLayout):
+class CollectionsSchoolTestingHomeLayout(LabelLayout):
     sku = "LCRY-1100"
-    barcode_type = 'SCHOOL TESTING'
+    barcode_type = 'SCHOOL TESTING HOME'
     copies_per_barcode = 2
+    reference = "seattleflu.org"
+
+
+class CollectionsSchoolTestingObservedLayout(LabelLayout):
+    sku = "LCRY-1100"
+    barcode_type = 'SCHOOL TESTING OBSERVED'
+    copies_per_barcode = 1
     reference = "seattleflu.org"
 
 
@@ -330,7 +337,8 @@ LAYOUTS = {
     'collections-uw-observed': CollectionsUWObservedLayout,
     'collections-uw-home': CollectionsUWHomeLayout,
     'collections-childcare': CollectionsChildcareLayout,
-    'collections-school-testing': CollectionsSchoolTestingLayout,
+    'collections-school-testing-home': CollectionsSchoolTestingHomeLayout,
+    'collections-school-testing-observed': CollectionsSchoolTestingObservedLayout,
     'collections-apple-respiratory': CollectionsAppleRespiratoryLayout,
     'collections-adult-family-home-outbreak': CollectionsAdultFamilyHomeOutbreakLayout,
     'collections-workplace-outbreak': CollectionsWorkplaceOutbreakLayout,


### PR DESCRIPTION
We now have two collection sets for the schools testing study. Use the same naming convention used for the UW Reopening study--"home" and "observed".

I minted and made labels locally. "SCHOOL TESTING OBSERVED <barcode>" does just fit onto the current label. Nothing gets truncated for home or observed.