### PR TITLE
Add collection sets for new studies to Manifest ETL

### DIFF
--- a/lib/id3c/cli/command/etl/manifest.py
+++ b/lib/id3c/cli/command/etl/manifest.py
@@ -77,6 +77,12 @@ def etl_manifest(*, db: DatabaseSession):
             "collections-uw-observed",
             "collections-household-general",
             "collections-childcare",
+            "collections-school-testing-home",
+            "collections-school-testing-observed",
+            "collections-apple-respiratory",
+            "collections-apple-respiratory-serial",
+            "collections-adult-family-home-outbreak",
+            "collections-workplace-outbreak",
         },
         "rdt": {"collections-fluathome.org"}
     }


### PR DESCRIPTION
We forgot to add the collection sets for the new studies to the
manifest ETL. As a result, samples with them are being skipped.