### PR TITLE
redcap: Include the project in two log lines which were missing it

### DIFF
--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -263,7 +263,7 @@ class Project:
                 for lower
                 in range(1, next_record_id, page_size)]
 
-        LOG.debug(f"Computed pages for record fetch: {pages!r}")
+        LOG.debug(f"Computed pages for record fetch for {self}: {pages!r}")
 
         for lower_bound, upper_bound in pages:
             page_filter = f"[{self.record_id_field}] >= {lower_bound}"
@@ -472,7 +472,7 @@ class Project:
         if "data" in loggable_parameters:
             loggable_parameters["data"] = "***MASKED***"
 
-        LOG.debug(f"Requesting content={content} from REDCap with params {loggable_parameters}")
+        LOG.debug(f"Requesting content={content} from REDCap with params {loggable_parameters} for {self}")
 
         headers = {
             'Content-type': 'application/x-www-form-urlencoded',

--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -42,6 +42,7 @@ class Project:
     api_token: str
     base_url: str
     dry_run: bool
+    id: int
     _details: dict
     _instruments: List[str] = None
     _events: List[str] = None
@@ -60,18 +61,13 @@ class Project:
 
         self.api_token = token or api_token(url, project_id)
         self.dry_run = bool(dry_run)
+        self.id = int(project_id)
 
         # Check if project details match our expectations
         self._details = self._fetch("project")
 
-        assert int(self.id) == int(project_id), \
-            f"REDCap API token provided for project {project_id} is actually for project {self.id} ({self.title!r})!"
-
-
-    @property
-    def id(self) -> int:
-        """Numeric ID of this project."""
-        return self._details["project_id"]
+        assert self.id == int(self._details["project_id"]), \
+            f"REDCap API token provided for project {self.id} is actually for project {self._details['project_id']} ({self.title!r})!"
 
 
     @property


### PR DESCRIPTION
Most lines already included the project info.

This is helpful when reading logs for a process that accesses multiple
REDCap projects.