### PR TITLE
Use supportsAllDrives when getting Google metadata

### DIFF
--- a/lib/id3c/cli/io/google.py
+++ b/lib/id3c/cli/io/google.py
@@ -87,6 +87,6 @@ def get_document_etag(document_id: str) -> str:
     Returns the etag of a Google Drive document.
     """
     drive_service = discovery.build("drive", "v2")
-    metadata = drive_service.files().get(fileId=document_id).execute()
+    metadata = drive_service.files().get(fileId=document_id, supportsAllDrives=True).execute()
 
     return metadata["etag"]


### PR DESCRIPTION
In the `files().get` call to get the metadata for a Google Drive document
specify supportsAllDrives=True. SFS has moved content into a shared
Google Drive, and without this parameter set to True we get a 404
error.

From https://developers.google.com/drive/api/v2/reference/files/get:
"Whether the requesting application supports both My Drives and shared
drives. (Default: false)"