### PR TITLE
Pin smartystreets version to < 4.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "pyyaml",
         "requests",
         "s3fs",
-        "smartystreets-python-sdk >= 4.0.1, != 4.7.0",
+        "smartystreets-python-sdk >= 4.0.1, != 4.7.0, < 4.8.0",
         "xlrd <=1.2.0",
 
         # We use pkg_resources, which (confusingly) is provided by setuptools.


### PR DESCRIPTION
Running with 4.8.0 deployed in production is giving this error:
"File "/opt/backoffice/id3c-production/.venv/lib/python3.6/site-packages/smartystreets_python_sdk/client_builder.py"
, line 6, in <module> from smartystreets_python_sdk.us_autocomplete_pro import Client as
USAutocompleteProClient ModuleNotFoundError: No module named
'smartystreets_python_sdk.us_autocomplete_pro'"

Pin a version < 4.8.0 for now.