### PR TITLE
Relax dep on SmartyStreets SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "pyyaml",
         "requests",
         "s3fs",
-        "smartystreets-python-sdk >= 4.0.1, != 4.7.0, < 4.8.0",
+        "smartystreets-python-sdk >= 4.0.1, != 4.7.0, != 4.8.0",
         "xlrd <=1.2.0",
 
         # We use pkg_resources, which (confusingly) is provided by setuptools.


### PR DESCRIPTION
Allows future releases while still excluding the known-bad release,
4.8.0.

SmartyStreets released 4.8.1 to fix the issue:

  https://github.com/smartystreets/smartystreets-python-sdk/issues/30