### PR TITLE
Add layout for yakima schools testing to labelmaker

### DIFF
--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -320,6 +320,20 @@ class CollectionsWorkplaceOutbreakLayout(LabelLayout):
     reference = "seattleflu.org"
 
 
+class CollectionsRadxupYakimaSchoolHomeLayout(LabelLayout):
+    sku = "LCRY-1100"
+    barcode_type = 'RADXUP YAKIMA HOME'
+    copies_per_barcode = 2
+    reference = "seattleflu.org"
+
+
+class CollectionsRadxupYakimaSchoolObservedLayout(LabelLayout):
+    sku = "LCRY-1100"
+    barcode_type = 'RADXUP YAKIMA OBSERVED'
+    copies_per_barcode = 1
+    reference = "seattleflu.org"
+
+
 LAYOUTS = {
     "samples": SamplesLayout,
     "collections-scan": CollectionsScanLayout,
@@ -350,6 +364,8 @@ LAYOUTS = {
     'collections-apple-respiratory-serial': CollectionsAppleRespiratorySerialLayout,
     'collections-adult-family-home-outbreak': CollectionsAdultFamilyHomeOutbreakLayout,
     'collections-workplace-outbreak': CollectionsWorkplaceOutbreakLayout,
+    'collections-radxup-yakima-schools-home': CollectionsRadxupYakimaSchoolHomeLayout,
+    'collections-radxup-yakima-schools-observed': CollectionsRadxupYakimaSchoolObservedLayout,
 }
 
 


### PR DESCRIPTION
Setting up the most commonly used layout settings for now for the yakima schools study.

This would be great to follow up with a refactor to allow an arg to `id3c identifier mint` that allows override of the layout's default `copies-per-barcode`