### PR TITLE
identifier/labelmaker: add --copies-per-barcode option

### DIFF
--- a/lib/id3c/cli/command/identifier.py
+++ b/lib/id3c/cli/command/identifier.py
@@ -51,6 +51,10 @@ def identifier():
     default = 'default',
     help = "Specify a desired label layout.")
 
+@click.option("--copies-per-barcode",
+    metavar = "<copies-per-barcode>",
+    help = "Specify a desired number of copies per barcode.")
+
 @click.option("--quiet", "-q",
     help = "Suppress printing of new identifiers to stdout",
     is_flag = True,
@@ -62,7 +66,7 @@ def identifier():
     flag_value = True)
 
 
-def mint(set_name, count, *, labels, layout, quiet, dry_run):
+def mint(set_name, count, *, labels, layout, copies_per_barcode, quiet, dry_run):
     """
     Mint new identifiers and make barcode labels.
 
@@ -95,7 +99,7 @@ def mint(set_name, count, *, labels, layout, quiet, dry_run):
             print(identifier.barcode, identifier.uuid, sep = "\t")
 
     if labels:
-        label_layout = labelmaker.layout_identifiers(set_name, minted, layout)
+        label_layout = labelmaker.layout_identifiers(set_name, minted, layout, copies_per_barcode)
         pdf = labelmaker.generate_pdf(label_layout)
         labels.write(pdf)
 
@@ -111,8 +115,12 @@ def mint(set_name, count, *, labels, layout, quiet, dry_run):
     default = 'default',
     help = "Specify a desired label layout.")
 
+@click.option("--copies-per-barcode",
+    metavar = "<copies-per-barcode>",
+    help = "Specify a desired number of copies per barcode.")
 
-def labels(filename, layout: str='default'):
+
+def labels(filename, layout: str='default', copies_per_barcode: int=None):
     """
     Make barcode labels for an existing batch of identifiers.
 
@@ -126,6 +134,9 @@ def labels(filename, layout: str='default'):
 
     If --layout is requested, the printable barcode labels will use the given
     version of the layout, if available.
+
+    The option --copies-per-barcode can be provded to change the number of
+    copies per barcode in the printable barcode labels.
 
     ¹ https://github.com/MullinsLab/Lab-Labels
     """
@@ -176,7 +187,7 @@ def labels(filename, layout: str='default'):
 
     assert len(identifiers) == chosen_batch.count
 
-    label_layout = labelmaker.layout_identifiers(chosen_batch.set_name, identifiers, layout)
+    label_layout = labelmaker.layout_identifiers(chosen_batch.set_name, identifiers, layout, copies_per_barcode)
     pdf = labelmaker.generate_pdf(label_layout)
     filename.write(pdf)
 

--- a/lib/id3c/cli/command/identifier.py
+++ b/lib/id3c/cli/command/identifier.py
@@ -52,8 +52,9 @@ def identifier():
     help = "Specify a desired label layout.")
 
 @click.option("--copies-per-barcode",
-    metavar = "<copies-per-barcode>",
-    help = "Specify a desired number of copies per barcode.")
+    type = click.Choice(['1','2']),
+    help = "Specify a desired number of copies per barcode. "
+           "Currently only allows values 1 or 2 to avoid bad UX for the label PDFs.")
 
 @click.option("--quiet", "-q",
     help = "Suppress printing of new identifiers to stdout",
@@ -116,8 +117,9 @@ def mint(set_name, count, *, labels, layout, copies_per_barcode, quiet, dry_run)
     help = "Specify a desired label layout.")
 
 @click.option("--copies-per-barcode",
-    metavar = "<copies-per-barcode>",
-    help = "Specify a desired number of copies per barcode.")
+    type = click.Choice(['1','2']),
+    help = "Specify a desired number of copies per barcode. "
+           "Currently only allows values 1 or 2 to avoid bad UX for the label PDFs.")
 
 
 def labels(filename, layout: str='default', copies_per_barcode: int=None):

--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -353,7 +353,8 @@ LAYOUTS = {
 }
 
 
-def layout_identifiers(set_name: str, identifiers: Iterable, layout: str='default') -> LabelLayout:
+def layout_identifiers(set_name: str, identifiers: Iterable,
+                       layout: str='default', copies_per_barcode: int=None) -> LabelLayout:
     """
     Use the layout associated with the given identifier *set_name* to make
     labels for the given *identifiers*.
@@ -361,7 +362,12 @@ def layout_identifiers(set_name: str, identifiers: Iterable, layout: str='defaul
     Each item in *identifiers* must have a ``barcode`` attribute.  These are
     passed to the layout.
     """
-    return LAYOUTS[set_name]([id.barcode for id in identifiers], layout)
+    layout_class = LAYOUTS[set_name]([id.barcode for id in identifiers], layout)
+
+    if copies_per_barcode:
+        setattr(layout_class, 'copies_per_barcode', copies_per_barcode)
+
+    return layout_class
 
 
 def generate_pdf(layout: LabelLayout, api: str = DEFAULT_LABEL_API) -> bytes:


### PR DESCRIPTION
When minting barcodes or printing labels, use the `--copies-per-barcode`
option to specify how many copies per barcode should be included in the
printable barcode labels.

NOTE: This is a naive overwrite of the default number. It does not take
into account the specific layout for better UX that may require blanks.
For example, changing the copies per barcode for the "samples" barcodes
can result in a confusing layout in the PDF.