### PR TITLE
geocode: Avoid extracting addresses from empty or whitespace-only strings

### DIFF
--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -281,7 +281,7 @@ def geocode_address(address: dict) -> dict:
         STREET_CLIENT = smartystreets_client_builder().build_us_street_api_client()
 
     lookup = us_street_lookup(address)
-    if not lookup.street:
+    if lookup.street is None or not lookup.street.strip():
         LOG.warning(f"Missing street address; can't geocode")
         return None
 

--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -386,6 +386,9 @@ def extract_address(address: dict) -> dict:
 
     address_text = ', '.join([str(val) for val in list(address.values()) if val])
 
+    if not address_text.strip():
+        return None
+
     lookup = ExtractLookup()
     lookup.text = address_text
 


### PR DESCRIPTION
SmartyStreets Python API throws an error when given an empty or
whitespace-only string.  Even if it didn't, there's no point in making a
request for an empty address.

Fixes an error we observed in production in the ETL for metadata about
UW residual samples.