### PR TITLE
Web API for identifiers and identifier sets

### DIFF
--- a/lib/id3c/api/__init__.py
+++ b/lib/id3c/api/__init__.py
@@ -3,6 +3,7 @@ Web API
 """
 import logging
 from flask import Flask
+from ..json import JsonEncoder
 from . import config
 from .routes import blueprints
 
@@ -13,6 +14,8 @@ LOG = logging.getLogger(__name__)
 def create_app():
     app = Flask(__name__)
     app.config.update(config.from_environ())
+
+    app.json_encoder = JsonEncoder # type: ignore
 
     for blueprint in blueprints:
         app.register_blueprint(blueprint)

--- a/lib/id3c/api/routes.py
+++ b/lib/id3c/api/routes.py
@@ -194,18 +194,30 @@ def get_identifier_set(name, *, session):
 
 
 @api_v1.route("/warehouse/identifier-sets/<name>", methods = ['PUT'])
+@content_types_accepted(["application/x-www-form-urlencoded", "multipart/form-data", None])
+@check_content_length
 @authenticated_datastore_session_required
 def put_identifier_set(name, *, session):
     """
     Make a new identifier set.
 
     PUT /warehouse/identifier-sets/*name* to create the set if it doesn't yet
-    exist.  201 Created is returned when the set is created, 204 No Content if
-    the set already existed.
+    exist.
+
+    If a *description* form parameter is provided, its value is set/updated in
+    the database.
+
+    201 Created is returned when the set is created or updated, 204 No
+    Content if the set already existed.
     """
     LOG.debug(f"Making identifier set «{name}»")
 
-    new_set = datastore.make_identifier_set(session, name)
+    fields = {}
+
+    if "description" in request.form:
+        fields["description"] = request.form["description"]
+
+    new_set = datastore.make_identifier_set(session, name, **fields)
 
     return "", 201 if new_set else 204
 

--- a/lib/id3c/api/routes.py
+++ b/lib/id3c/api/routes.py
@@ -4,7 +4,7 @@ API route definitions.
 import json
 import logging
 import pkg_resources
-from flask import Blueprint, request, send_file
+from flask import Blueprint, jsonify, request, send_file
 from . import datastore
 from .utils.routes import authenticated_datastore_session_required, content_types_accepted, check_content_length
 
@@ -143,6 +143,22 @@ def receive_fhir(*, session):
     datastore.store_fhir(session, document)
 
     return "", 204
+
+
+@api_v1.route("/warehouse/identifier/<id>", methods = ['GET'])
+@authenticated_datastore_session_required
+def get_identifier(id, *, session):
+    """
+    Retrieve an identifier's metadata.
+
+    GET /warehouse/identifier/*id* to receive a JSON object containing the
+    identifier's record.  *id* may be a full UUID or shortened barcode.
+    """
+    LOG.debug(f"Fetching identifier «{id}»")
+
+    identifier = datastore.fetch_identifier(session, id)
+
+    return jsonify(identifier._asdict())
 
 
 # Load all extra API routes from extensions

--- a/lib/id3c/api/routes.py
+++ b/lib/id3c/api/routes.py
@@ -161,6 +161,55 @@ def get_identifier(id, *, session):
     return jsonify(identifier._asdict())
 
 
+@api_v1.route("/warehouse/identifier-sets", methods = ['GET'])
+@authenticated_datastore_session_required
+def get_identifier_sets(*, session):
+    """
+    Retrieve metadata about all identifier sets.
+
+    GET /warehouse/identifier-set to receive a JSON array of objects, each
+    containing a set's metadata fields.
+    """
+    LOG.debug(f"Fetching identifier sets")
+
+    sets = datastore.fetch_identifier_sets(session)
+
+    return jsonify([ set._asdict() for set in sets ])
+
+
+@api_v1.route("/warehouse/identifier-sets/<name>", methods = ['GET'])
+@authenticated_datastore_session_required
+def get_identifier_set(name, *, session):
+    """
+    Retrieve an identifier set's metadata.
+
+    GET /warehouse/identifier-set/*name* to receive a JSON object containing the set's
+    metadata fields.
+    """
+    LOG.debug(f"Fetching identifier set «{name}»")
+
+    set = datastore.fetch_identifier_set(session, name)
+
+    return jsonify(set._asdict())
+
+
+@api_v1.route("/warehouse/identifier-sets/<name>", methods = ['PUT'])
+@authenticated_datastore_session_required
+def put_identifier_set(name, *, session):
+    """
+    Make a new identifier set.
+
+    PUT /warehouse/identifier-sets/*name* to create the set if it doesn't yet
+    exist.  201 Created is returned when the set is created, 204 No Content if
+    the set already existed.
+    """
+    LOG.debug(f"Making identifier set «{name}»")
+
+    new_set = datastore.make_identifier_set(session, name)
+
+    return "", 201 if new_set else 204
+
+
 # Load all extra API routes from extensions
 # Needs to be at the end of route declarations to allow customization of
 # existing routes and avoid dependency errors

--- a/lib/id3c/api/static/index.html
+++ b/lib/id3c/api/static/index.html
@@ -79,6 +79,10 @@
     <p>Stores the request data as a consensus genome document in a receiving
     area of the study database.
 
+    <h3 class="code">GET /v1/warehouse/identifier/<em>&lt;id&gt;</em></h3>
+    <p>Retrieve metadata about an identifier <em>id</em>.  <em>id</em> may be a
+    full UUID or shortened barcode.
+
     <hr>
 
     <h2>Legacy Routes</h2>

--- a/lib/id3c/api/static/index.html
+++ b/lib/id3c/api/static/index.html
@@ -83,6 +83,16 @@
     <p>Retrieve metadata about an identifier <em>id</em>.  <em>id</em> may be a
     full UUID or shortened barcode.
 
+    <h3 class="code">GET /v1/warehouse/identifier-sets</h3>
+    <p>Retrieve metadata about all identifier sets.
+
+    <h3 class="code">GET /v1/warehouse/identifier-sets/<em>&lt;name&gt;</em></h3>
+    <p>Retrieve metadata about an identifier set <em>name</em>.
+
+    <h3 class="code">PUT /v1/warehouse/identifier-sets/<em>&lt;set&gt;</em></h3>
+    <p>Make a new identifier set <em>name</em>.  Idempotent if the set already
+    exists.
+
     <hr>
 
     <h2>Legacy Routes</h2>

--- a/lib/id3c/api/static/index.html
+++ b/lib/id3c/api/static/index.html
@@ -91,7 +91,7 @@
 
     <h3 class="code">PUT /v1/warehouse/identifier-sets/<em>&lt;set&gt;</em></h3>
     <p>Make a new identifier set <em>name</em>.  Idempotent if the set already
-    exists.
+    exists.  An optional <em>description</em> parameter may be provided.
 
     <hr>
 

--- a/lib/id3c/api/utils/routes.py
+++ b/lib/id3c/api/utils/routes.py
@@ -71,7 +71,8 @@ def check_content_length(route):
     """
     @wraps(route)
     def wrapped_route(*args, **kwargs):
-        if request.content_length > request.max_content_length: # type: ignore
+        if (request.content_length is not None
+        and request.content_length > request.max_content_length): # type: ignore
             raise RequestEntityTooLarge(f"Content-Length exceeded {request.max_content_length} bytes")
 
         return route(*args, **kwargs)

--- a/lib/id3c/json.py
+++ b/lib/id3c/json.py
@@ -4,6 +4,7 @@ Standardized JSON conventions.
 import json
 from datetime import datetime
 from typing import Iterable
+from uuid import UUID
 from .utils import contextualize_char, shorten_left
 
 
@@ -65,9 +66,14 @@ class JsonEncoder(json.JSONEncoder):
         Serializes:
 
         * :class:`~datetime.datetime` using :meth:`~datetime.datetime.isoformat()`
+        * :class:`~uuid.UUID` using ``str()``
         """
         if isinstance(value, datetime):
             return value.isoformat()
+
+        elif isinstance(value, UUID):
+            return str(value)
+
         else:
             # Let the base class raise the TypeError
             return super().default(value)

--- a/lib/id3c/json.py
+++ b/lib/id3c/json.py
@@ -47,6 +47,17 @@ class JsonEncoder(json.JSONEncoder):
     Encodes Python values into JSON for non-standard objects.
     """
 
+    def __init__(self, *args, **kwargs):
+        """
+        Disallows the floating point values NaN, Infinity, and -Infinity.
+
+        Python's :class:`json` allows them by default because they work with
+        JSON-as-JavaScript, but they don't work with spec-compliant JSON
+        parsers.
+        """
+        kwargs["allow_nan"] = False
+        super().__init__(*args, **kwargs)
+
     def default(self, value):
         """
         Returns *value* as JSON or raises a TypeError.

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         "requests",
         "s3fs",
         "smartystreets-python-sdk >= 4.0.1, != 4.7.0, != 4.8.0",
+        "typing_extensions >=3.7.4",
         "xlrd <=1.2.0",
 
         # We use pkg_resources, which (confusingly) is provided by setuptools.


### PR DESCRIPTION
Refresh of [a long-standing WIP](https://github.com/seattleflu/id3c/compare/wip/identifier-api) from a couple years ago to add an identifier API. It had slightly different but overlapping motivations at the time. I refreshed it on the latest code and added an identifier lookup endpoint which could be used for validation.

Marked as draft because I expect we'll want some further consideration first. We don't have to use this as-is, but I figured it could be a starting point for discussion about what we do want there with much of the plumbing done.

Commit messages contain details.