### PR TITLE
Add use column to identifier_set

### DIFF
--- a/lib/id3c/api/static/index.html
+++ b/lib/id3c/api/static/index.html
@@ -91,7 +91,12 @@
 
     <h3 class="code">PUT /v1/warehouse/identifier-sets/<em>&lt;set&gt;</em></h3>
     <p>Make a new identifier set <em>name</em>.  Idempotent if the set already
-    exists.  An optional <em>description</em> parameter may be provided.
+    exists.  Optional <em>description</em> parameter may be provided. A <em>use</em>
+    parameter is required for new sets and is optional if only updating
+    <em>description</em> on an existing set.
+
+    <h3 class="code">GET /v1/warehouse/identifier-set_uses</h3>
+    <p>Retrieve metadata about all identifier set uses.
 
     <hr>
 

--- a/lib/id3c/db/__init__.py
+++ b/lib/id3c/db/__init__.py
@@ -101,7 +101,8 @@ def find_identifier(db: DatabaseSession, barcode: str) -> Optional[IdentifierRec
         select uuid::text,
                barcode,
                generated,
-               identifier_set.name as set_name
+               identifier_set.name as set_name,
+               identifier_set.use as set_use
           from warehouse.identifier
           join warehouse.identifier_set using (identifier_set_id)
          where barcode = %s

--- a/schema/deploy/warehouse/identifier-set-use.sql
+++ b/schema/deploy/warehouse/identifier-set-use.sql
@@ -1,0 +1,21 @@
+-- Deploy seattleflu/schema:warehouse/identifier-set-use to pg
+-- requires: warehouse/schema
+-- requires: citext
+
+begin;
+
+create table warehouse.identifier_set_use (
+    use citext primary key,
+    description text
+);
+
+comment on table warehouse.identifier_set_use is
+    'Controlled vocabulary for warehouse.identifier_set.use';
+
+comment on column warehouse.identifier_set_use.use is
+    'A standard identifier use type, e.g. sample, collection, clia';
+
+comment on column warehouse.encounter_location_relation.priority is
+    'A plain text description of this identifier use type';
+
+commit;

--- a/schema/deploy/warehouse/identifier-set-use.sql
+++ b/schema/deploy/warehouse/identifier-set-use.sql
@@ -15,7 +15,7 @@ comment on table warehouse.identifier_set_use is
 comment on column warehouse.identifier_set_use.use is
     'A standard identifier use type, e.g. sample, collection, clia';
 
-comment on column warehouse.encounter_location_relation.priority is
+comment on column warehouse.identifier_set_use.description is
     'A plain text description of this identifier use type';
 
 commit;

--- a/schema/deploy/warehouse/identifier-set-use/data.sql
+++ b/schema/deploy/warehouse/identifier-set-use/data.sql
@@ -5,11 +5,11 @@ begin;
 
 insert into warehouse.identifier_set_use (use, description)
     values
-        ('sample', 'Sample ID'),
-        ('collection', 'Collection ID'),
-        ('clia', 'CLIA ID'),
-        ('kit','Test kit ID'),
-        ('test-strip','Test strip ID')
+        ('sample', 'Identifiers for samples received and processed by the lab'),
+        ('collection', 'Identifiers for collection tubes'),
+        ('clia', 'Secondary identifiers for CLIA compliance'),
+        ('kit','Identifiers for test kits'),
+        ('test-strip','Identifiers for test strips')
     on conflict (use) do update set
         description = excluded.description
 ;

--- a/schema/deploy/warehouse/identifier-set-use/data.sql
+++ b/schema/deploy/warehouse/identifier-set-use/data.sql
@@ -1,0 +1,17 @@
+-- Deploy seattleflu/schema:warehouse/identifier-set-use/data to pg
+-- requires: warehouse/identifier-set-use
+
+begin;
+
+insert into warehouse.identifier_set_use (use, description)
+    values
+        ('sample', 'Sample ID'),
+        ('collection', 'Collection ID'),
+        ('clia', 'CLIA ID'),
+        ('kit','Test kit ID'),
+        ('test-strip','Test strip ID')
+    on conflict (use) do update set
+        description = excluded.description
+;
+
+commit;

--- a/schema/deploy/warehouse/identifier-set/use-not-null.sql
+++ b/schema/deploy/warehouse/identifier-set/use-not-null.sql
@@ -1,0 +1,8 @@
+-- Deploy seattleflu/schema:warehouse/identifier-set/use-not-null to pg
+-- requires: warehouse/identifier-set/use
+
+begin;
+
+alter table warehouse.identifier_set alter column use set not null;
+
+commit;

--- a/schema/deploy/warehouse/identifier-set/use.sql
+++ b/schema/deploy/warehouse/identifier-set/use.sql
@@ -1,0 +1,15 @@
+-- Deploy seattleflu/schema:warehouse/identifier-set/use to pg
+-- requires: warehouse/identifier
+-- requires: warehouse/identifier-set-use
+
+begin;
+
+alter table warehouse.identifier_set
+    add column use citext;
+
+alter table warehouse.identifier_set
+    add constraint identifier_set_use_fkey
+        foreign key (use)
+        references warehouse.identifier_set_use (use);
+
+commit;

--- a/schema/deploy/warehouse/identifier/indexes/identifier_set_id_btree.sql
+++ b/schema/deploy/warehouse/identifier/indexes/identifier_set_id_btree.sql
@@ -1,0 +1,8 @@
+-- Deploy seattleflu/schema:warehouse/identifier/indexes/identifier_set_id_btree to pg
+-- requires: warehouse/identifier
+
+begin;
+
+create index identifier_set_id_idx on warehouse.identifier using btree (identifier_set_id);
+
+commit;

--- a/schema/revert/warehouse/identifier-set-use.sql
+++ b/schema/revert/warehouse/identifier-set-use.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/identifier-set-use from pg
+
+begin;
+
+drop table warehouse.identifier_set_use;
+
+commit;

--- a/schema/revert/warehouse/identifier-set-use/data.sql
+++ b/schema/revert/warehouse/identifier-set-use/data.sql
@@ -1,0 +1,13 @@
+-- Revert seattleflu/schema:warehouse/identifier-set-use/data from pg
+
+begin;
+
+delete from warehouse.identifier_set_use where use in (
+    'sample',
+    'collection',
+    'clia',
+    'kit',
+    'test-strip'
+);
+
+commit;

--- a/schema/revert/warehouse/identifier-set/use-not-null.sql
+++ b/schema/revert/warehouse/identifier-set/use-not-null.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/identifier-set/use-not-null from pg
+
+begin;
+
+alter table warehouse.identifier_set alter column use drop not null;
+
+commit;

--- a/schema/revert/warehouse/identifier-set/use.sql
+++ b/schema/revert/warehouse/identifier-set/use.sql
@@ -1,0 +1,11 @@
+-- Revert seattleflu/schema:warehouse/identifier-set/use from pg
+
+begin;
+
+alter table warehouse.identifier_set
+    drop constraint identifier_set_use_fkey;
+
+alter table warehouse.identifier_set
+    drop column use;
+
+commit;

--- a/schema/revert/warehouse/identifier/indexes/identifier_set_id_btree.sql
+++ b/schema/revert/warehouse/identifier/indexes/identifier_set_id_btree.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/identifier/indexes/identifier_set_id_btree from pg
+
+begin;
+
+drop index warehouse.identifier_set_id_idx;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -224,3 +224,8 @@ warehouse/identifier/indexes/identifier_barcode_slices_null [functions/barcode_s
 
 functions/barcode_slices [functions/barcode_slices@2021-02-27] 2021-02-27T16:10:36Z Chris Craft <jccraft@uw.edu> # Explicitly mark public schema usage to fix db restore
 @2021-02-27b 2021-02-27T16:33:09Z Chris Craft <jccraft@uw.edu> # Schema as of later on 27 Feb 2021
+
+warehouse/identifier-set-use 2021-07-04T03:43:50Z Dave Reinhart <davidrr@uw.edu> # Add identifier_set_use table
+warehouse/identifier-set-use/data [warehouse/identifier-set-use] 2021-07-04T03:52:19Z Dave Reinhart <davidrr@uw.edu> # Initial records for identifier_set_use table
+warehouse/identifier-set/use [warehouse/identifier warehouse/identifier-set-use] 2021-07-04T04:05:25Z Dave Reinhart <davidrr@uw.edu> # Add use column to identifier_set table
+@2021-07-03 2021-07-04T04:31:31Z Dave Reinhart <davidrr@uw.edu> # Schema as of 03 Jul 2021

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -229,3 +229,7 @@ warehouse/identifier-set-use 2021-07-04T03:43:50Z Dave Reinhart <davidrr@uw.edu>
 warehouse/identifier-set-use/data [warehouse/identifier-set-use] 2021-07-04T03:52:19Z Dave Reinhart <davidrr@uw.edu> # Initial records for identifier_set_use table
 warehouse/identifier-set/use [warehouse/identifier warehouse/identifier-set-use] 2021-07-04T04:05:25Z Dave Reinhart <davidrr@uw.edu> # Add use column to identifier_set table
 @2021-07-03 2021-07-04T04:31:31Z Dave Reinhart <davidrr@uw.edu> # Schema as of 03 Jul 2021
+
+warehouse/identifier-set/use-not-null 2021-07-06T22:26:14Z Dave Reinhart <davidrr@uw.edu> # Add not null to identifier-set use column
+warehouse/identifier/indexes/identifier_set_id_btree 2021-07-06T22:33:41Z Dave Reinhart <davidrr@uw.edu> # Add index to identifier on identifier_set_id column
+@2021-07-06 2021-07-06T22:38:05Z Dave Reinhart <davidrr@uw.edu> # Schema as of 06 Jul 2021

--- a/schema/verify/warehouse/identifier-set-use.sql
+++ b/schema/verify/warehouse/identifier-set-use.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/identifier-set-use on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/identifier-set-use/data.sql
+++ b/schema/verify/warehouse/identifier-set-use/data.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/identifier-set-use/data on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/identifier-set/use-not-null.sql
+++ b/schema/verify/warehouse/identifier-set/use-not-null.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/identifier-set/use-not-null on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/identifier-set/use.sql
+++ b/schema/verify/warehouse/identifier-set/use.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/identifier-set/use on pg
+
+begin;
+
+
+
+rollback;

--- a/schema/verify/warehouse/identifier/indexes/identifier_set_id_btree.sql
+++ b/schema/verify/warehouse/identifier/indexes/identifier_set_id_btree.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/identifier/indexes/identifier_set_id_btree on pg
+
+begin;
+
+
+
+rollback;


### PR DESCRIPTION
Identifier type (sample, collection, clia, etc.) is missing from the data
model, currenly only  encoded through identifier_set naming convention. Adding
it to identifier_set makes it more explicitly defined which will simplify
implementations of API and ETL functions and allow for future migration away
from using multiple identifier columns in sample table.