### PR TITLE
etl: Add new UW id set to FHIR and manifest ETLs

### DIFF
--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -75,6 +75,7 @@ EXPECTED_COLLECTION_IDENTIFIER_SETS = [
     'collections-scan-kiosks',
     'collections-uw-home',
     'collections-uw-observed',
+    'collections-uw-tiny-swabs',
     'collections-household-general',
     'collections-childcare',
 ]

--- a/lib/id3c/cli/command/etl/manifest.py
+++ b/lib/id3c/cli/command/etl/manifest.py
@@ -75,6 +75,7 @@ def etl_manifest(*, db: DatabaseSession):
             "collections-validation",
             "collections-uw-home",
             "collections-uw-observed",
+            "collections-uw-tiny-swabs",
             "collections-household-general",
             "collections-childcare",
             "collections-school-testing-home",


### PR DESCRIPTION
Add the new UW identifier set collections-uw-tiny-swabs to the expected
sets for the FHIR and manifest ETLs.

Note: we didn't ingest data from the tiny swabs pilot, this is preparation
for when we start using that identifier set for the HCT redcap project