### PR TITLE
wip! api: Add endpoint for minting identifiers

### DIFF
--- a/lib/id3c/api/datastore.py
+++ b/lib/id3c/api/datastore.py
@@ -290,6 +290,24 @@ def make_identifier_set(session: DatabaseSession, name: str, **fields) -> bool:
 
 
 @export
+@catch_permission_denied
+def mint_identifiers(session: DatabaseSession, name: str, n: int) -> None:
+    """
+    Generate *n* new identifiers in the set *name*.
+
+    Raises a :class:`~werkzeug.exceptions.NotFound` exception if the set *name*
+    doesn't exist and a :class:`Forbidden` exception if the database reports a
+    `permission denied` error.
+    """
+    with session:
+        try:
+            return db.mint_identifiers(session, name, n)
+
+        except db.IdentifierSetNotFoundError as error:
+            raise NotFound(str(error)) from None
+
+
+@export
 class BadRequestDatabaseError(BadRequest):
     """
     Subclass of :class:`id3c.api.exceptions.BadRequest` which takes a


### PR DESCRIPTION
I wrote this endpoint over 2 years ago while integrating identifier
minting and barcode label generation, only to end up refactoring the
bulk of it out and generating labels via a CLI command instead.  With a
web interface for minting new identifiers in mind, I kept the code
around as a wip branch.  I thought of it again as we're thinking about
identifier API integration with the BBI LIMS, so I updated the code to
account for changes that happened in the interim.

We should consider what limits on "n" (if any?) are appropriate.  I'm
not sure what reasonable bound would be.  Here's the current summary
stats of batch size for all we've minted so far:

    min          1
    mode     1,040
    max     11,900

Stepping back from n, I think what a limit would really seek to prevent
is minting reqs that run "forever". We can't guarantee this just through
n alone (although very small n might approximate it well enough), so
maybe the more appropriate thing would be an explicit time limit. There
is some existing limit on request/response duration already at the web
server level (both at uWSGI and Apache, I believe), so that may provide
enough of a time limit if the corresponding database session is
terminated when the request is. But I'm not sure that's the case.

This also means that we may not be able to use this API as-is to mint
large batches of identifiers without increasing existing
request/response duration limits, possibly to unreasonable levels. An
async API would obviate that issue, but then require a minting job queue
and polling of job status by the client. (We've talked about this in the
past in related convos.)

(Extracted from https://github.com/seattleflu/id3c/pull/230 after discussion.)