### PR TITLE
geocode: Support specifying explicit SmartyStreets licenses to use

### DIFF
--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -303,9 +303,16 @@ def smartystreets_client_builder():
     Returns a new :class:`smartystreets_python_sdk.ClientBuilder` using
     credentials from the required environment variables
     ``SMARTYSTREETS_AUTH_ID`` and ``SMARTYSTREETS_AUTH_TOKEN``.
+
+    The environment variable ``SMARTYSTREETS_LICENSES`` can be used to
+    explicitly specify a comma-separated list of one or more licenses to
+    consider for the API request.  By default no licenses are specified.  See
+    `<https://www.smartystreets.com/docs/cloud/licensing>`__ for more
+    information on licensing.
     """
     auth_id = environ.get('SMARTYSTREETS_AUTH_ID')
     auth_token = environ.get('SMARTYSTREETS_AUTH_TOKEN')
+    licenses = environ.get('SMARTYSTREETS_LICENSES', '').split(",")
 
     if not auth_id and not auth_token:
         raise Exception("The environment variables SMARTYSTREETS_AUTH_ID and SMARTYSTREETS_AUTH_TOKEN are required.")
@@ -314,7 +321,7 @@ def smartystreets_client_builder():
     elif not auth_token:
         raise Exception("The environment variable SMARTYSTREETS_AUTH_TOKEN is required.")
 
-    return ClientBuilder(StaticCredentials(auth_id, auth_token))
+    return ClientBuilder(StaticCredentials(auth_id, auth_token)).with_licenses(licenses)
 
 
 def us_street_lookup(address: dict) -> Lookup:

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "pyyaml",
         "requests",
         "s3fs",
-        "smartystreets-python-sdk >= 4.0.1, != 4.7.0, != 4.8.0",
+        "smartystreets-python-sdk >= 4.6.0, != 4.7.0, != 4.8.0",
         "typing_extensions >=3.7.4",
         "xlrd <=1.2.0",
 


### PR DESCRIPTION
This is sometimes necessary if more than one license/plan is associated
with an account.  The default behaviour is unchanged.  Requires a
version bump on the SmartyStreets SDK dep, as the license handling was
only added in 4.6.0.

I made this change while making other changes to locally test
SmartyStreets' new "enhanced" lookups.  This knob can be necessary to
resolve ambiguity when there are multiple subscriptions active, which
seems like a situation that could easily arise at some point in
production, as it's determined by our SmartyStreets account, not
anything we deploy.  It'd be nice for it to already exist before its
needed to fix a broken system!