### PR TITLE
trs/wip/metrics

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -483,6 +483,19 @@
             "markers": "python_full_version >= '3.6.1'",
             "version": "==1.1.5"
         },
+        "prometheus-client": {
+            "hashes": [
+                "sha256:9da7b32f02439d8c04f7777021c304ed51d9ec180604700c1ba72a4d44dceb03",
+                "sha256:b08c34c328e1bf5961f0b4352668e6c8f145b4a087e09b7296ef62cbe4693d35"
+            ],
+            "version": "==0.9.0"
+        },
+        "prometheus-flask-exporter": {
+            "hashes": [
+                "sha256:01c8282eb695596531f29f4869c1b127e1918af4f191f1215c4b0b0d081f757e"
+            ],
+            "version": "==0.18.1"
+        },
         "protobuf": {
             "hashes": [
                 "sha256:0e247612fadda953047f53301a7b0407cb0c3cb4ae25a6fde661597a04039b3c",

--- a/lib/id3c/api/__init__.py
+++ b/lib/id3c/api/__init__.py
@@ -4,6 +4,7 @@ Web API
 import logging
 from flask import Flask
 from . import config
+from .metrics import metrics
 from .routes import blueprints
 
 
@@ -16,6 +17,8 @@ def create_app():
 
     for blueprint in blueprints:
         app.register_blueprint(blueprint)
+
+    metrics.init_app(app)
 
     LOG.debug(f"app root is {app.root_path}")
     LOG.debug(f"app static directory is {app.static_folder}")

--- a/lib/id3c/api/metrics.py
+++ b/lib/id3c/api/metrics.py
@@ -1,0 +1,19 @@
+"""
+Web API metrics.
+"""
+import prometheus_flask_exporter
+import prometheus_flask_exporter.multiprocess
+
+
+if "prometheus_multiproc_dir" in os.environ:
+    FlaskMetrics = prometheus_flask_exporter.multiprocess.MultiprocessPrometheusMetrics
+else:
+    FlaskMetrics = prometheus_flask_exporter.PrometheusMetrics
+
+
+# This instance is used by both our routes and create_app().
+metrics = FlaskMetrics(
+    app = None,
+    path = None,
+    defaults_prefix = prometheus_flask_exporter.NO_PREFIX,
+    default_latency_as_histogram = False)

--- a/lib/id3c/metrics.py
+++ b/lib/id3c/metrics.py
@@ -1,0 +1,56 @@
+"""
+Metrics handling functions.
+"""
+import logging
+from prometheus_client.core import GaugeMetricFamily
+from psycopg2.errors import InsufficientPrivilege
+from .db import DatabaseSession
+
+
+LOG = logging.getLogger(__name__)
+
+
+class DatabaseCollector:
+    """
+    Collects metrics from the database, using an existing *session*.
+    """
+    def __init__(self, session: DatabaseSession):
+        self.session = session
+
+
+    def collect(self):
+        with self.session:
+            yield from self.estimated_row_total()
+
+
+    def estimated_row_total(self):
+        family = GaugeMetricFamily(
+            "id3c_estimated_row_total",
+            "Estimated number of rows in an ID3C database table",
+            labels = ("schema", "table"))
+
+        try:
+            metrics = self.session.fetch_all(
+                """
+                select
+                    ns.nspname          as schema,
+                    c.relname           as table,
+                    c.reltuples::bigint as estimated_row_count
+                from
+                    pg_catalog.pg_class c
+                    join pg_catalog.pg_namespace ns on (c.relnamespace = ns.oid)
+                where
+                    ns.nspname in ('receiving', 'warehouse') and
+                    c.relkind = 'r'
+                order by
+                    schema,
+                    "table"
+                """)
+        except InsufficientPrivilege as error:
+            LOG.error(f"Permission denied when collecting id3c_estimated_row_total metrics: {error}")
+            return
+
+        for metric in metrics:
+            family.add_metric((metric.schema, metric.table), metric.estimated_row_count)
+
+        yield family

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ setup(
         "more-itertools",
         "oauth2client >2.0.0,<4.0.0",
         "pandas >=1.0.1,<2",
+        "prometheus_client",
+        "prometheus_flask_exporter",
         "psycopg2 >=2.8,<3",
         "pyyaml",
         "requests",


### PR DESCRIPTION
wip! api: Expose api- and database-level metrics for Prometheus to scrape

This will let us understand both the volume of requests and request rate
as well as how long requests to the various endpoints are taking, so we
can look at bottlenecks.

Transparently uses a collector that supports multiple processes since in
production we use a hybrid multiprocess and threaded deployment with
uWSGI.  This requires a directory for collecting the metrics from each
individual process, which are then aggregated and exported.  Metrics are
exported at /v1/metrics.

If no collection directory is defined, then metrics are not collected
and exported.

Disables the default "flask_" prefix on metric names in order to use the
standard Prometheus http_* metrics names as exported by other services.

Disables the histogram metric for request durations to result in a
summary metric instead, which is simpler to deal with on the query side
and should be enough for our needs.