### PR TITLE
trs/wip/metrics-platform

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -483,6 +483,13 @@
             "markers": "python_full_version >= '3.6.1'",
             "version": "==1.1.5"
         },
+        "prometheus-client": {
+            "hashes": [
+                "sha256:9da7b32f02439d8c04f7777021c304ed51d9ec180604700c1ba72a4d44dceb03",
+                "sha256:b08c34c328e1bf5961f0b4352668e6c8f145b4a087e09b7296ef62cbe4693d35"
+            ],
+            "version": "==0.9.0"
+        },
         "protobuf": {
             "hashes": [
                 "sha256:0e247612fadda953047f53301a7b0407cb0c3cb4ae25a6fde661597a04039b3c",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -490,6 +490,12 @@
             ],
             "version": "==0.9.0"
         },
+        "prometheus-flask-exporter": {
+            "hashes": [
+                "sha256:01c8282eb695596531f29f4869c1b127e1918af4f191f1215c4b0b0d081f757e"
+            ],
+            "version": "==0.18.1"
+        },
         "protobuf": {
             "hashes": [
                 "sha256:0e247612fadda953047f53301a7b0407cb0c3cb4ae25a6fde661597a04039b3c",

--- a/lib/id3c/api/__init__.py
+++ b/lib/id3c/api/__init__.py
@@ -3,7 +3,7 @@ Web API
 """
 import logging
 from flask import Flask
-from . import config
+from . import config, metrics
 from .routes import blueprints
 
 
@@ -16,6 +16,8 @@ def create_app():
 
     for blueprint in blueprints:
         app.register_blueprint(blueprint)
+
+    metrics.register_app(app)
 
     LOG.debug(f"app root is {app.root_path}")
     LOG.debug(f"app static directory is {app.static_folder}")

--- a/lib/id3c/api/metrics.py
+++ b/lib/id3c/api/metrics.py
@@ -1,0 +1,27 @@
+"""
+Web API metrics.
+"""
+import os
+import prometheus_flask_exporter
+import prometheus_flask_exporter.multiprocess
+
+
+if "prometheus_multiproc_dir" in os.environ:
+    FlaskMetrics = prometheus_flask_exporter.multiprocess.MultiprocessPrometheusMetrics
+    MULTIPROCESS = True
+
+else:
+    FlaskMetrics = prometheus_flask_exporter.PrometheusMetrics
+    MULTIPROCESS = False
+
+
+# This instance is used by both our routes and create_app().
+XXX = FlaskMetrics(
+    app = None,
+    path = None,
+    defaults_prefix = prometheus_flask_exporter.NO_PREFIX,
+    default_latency_as_histogram = False)
+
+
+def register_app(app):
+    XXX.init_app(app)

--- a/lib/id3c/api/metrics.py
+++ b/lib/id3c/api/metrics.py
@@ -2,8 +2,11 @@
 Web API metrics.
 """
 import os
+from prometheus_client import CollectorRegistry, GCCollector, PlatformCollector, ProcessCollector
 import prometheus_flask_exporter
 import prometheus_flask_exporter.multiprocess
+
+from ..metrics import MultiProcessWriter
 
 
 if "prometheus_multiproc_dir" in os.environ:
@@ -25,3 +28,14 @@ XXX = FlaskMetrics(
 
 def register_app(app):
     XXX.init_app(app)
+
+    # XXX TODO FIXME needs to be postfork for a pre-forking server like uWSGI
+    if MULTIPROCESS:
+        registry = CollectorRegistry(auto_describe = True)
+
+        ProcessCollector(registry = registry)
+        PlatformCollector(registry = registry)
+        GCCollector(registry = registry)
+
+        writer = MultiProcessWriter(registry)
+        writer.start()

--- a/lib/id3c/metrics.py
+++ b/lib/id3c/metrics.py
@@ -2,17 +2,12 @@
 Metrics handling functions.
 """
 import logging
-import prometheus_client
 from prometheus_client.core import GaugeMetricFamily
 from psycopg2.errors import InsufficientPrivilege
 from .db import DatabaseSession
 
 
 LOG = logging.getLogger(__name__)
-
-CollectorRegistry = prometheus_client.CollectorRegistry
-
-make_wsgi_app = prometheus_client.make_wsgi_app
 
 
 class DatabaseCollector:

--- a/lib/id3c/metrics.py
+++ b/lib/id3c/metrics.py
@@ -1,0 +1,61 @@
+"""
+Metrics handling functions.
+"""
+import logging
+import prometheus_client
+from prometheus_client.core import GaugeMetricFamily
+from psycopg2.errors import InsufficientPrivilege
+from .db import DatabaseSession
+
+
+LOG = logging.getLogger(__name__)
+
+CollectorRegistry = prometheus_client.CollectorRegistry
+
+make_wsgi_app = prometheus_client.make_wsgi_app
+
+
+class DatabaseCollector:
+    """
+    Collects metrics from the database, using an existing *session*.
+    """
+    def __init__(self, session: DatabaseSession):
+        self.session = session
+
+
+    def collect(self):
+        with self.session:
+            yield from self.estimated_row_total()
+
+
+    def estimated_row_total(self):
+        family = GaugeMetricFamily(
+            "id3c_estimated_row_total",
+            "Estimated number of rows in an ID3C database table",
+            labels = ("schema", "table"))
+
+        try:
+            metrics = self.session.fetch_all(
+                """
+                select
+                    ns.nspname          as schema,
+                    c.relname           as table,
+                    c.reltuples::bigint as estimated_row_count
+                from
+                    pg_catalog.pg_class c
+                    join pg_catalog.pg_namespace ns on (c.relnamespace = ns.oid)
+                where
+                    ns.nspname in ('receiving', 'warehouse') and
+                    c.relkind = 'r'
+                order by
+                    schema,
+                    "table"
+                """)
+        except InsufficientPrivilege as error:
+            LOG.error(f"Permission denied when collecting id3c_estimated_row_total metrics: {error}")
+            return
+
+        for metric in metrics:
+            family.add_metric((metric.schema, metric.table), metric.estimated_row_count)
+
+        yield family

--- a/lib/id3c/utils.py
+++ b/lib/id3c/utils.py
@@ -1,6 +1,8 @@
 """
 Utilities.
 """
+import ctypes
+import threading
 from typing import Any, Sequence, Union
 
 
@@ -94,3 +96,21 @@ def shorten(text, length, placeholder):
         return text[0:length - len(placeholder)] + placeholder
     else:
         return text
+
+
+LIBCAP = None
+
+def set_thread_name(thread: threading.Thread):
+    global LIBCAP
+
+    if LIBCAP is None:
+        try:
+            LIBCAP = ctypes.CDLL("libcap.so.2")
+        except:
+            LIBCAP = False
+
+    if not LIBCAP:
+        return
+
+    # From the prctl(2) manpage, PR_SET_NAME is 15.
+    LIBCAP.prctl(15, thread.name.encode())

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "more-itertools",
         "oauth2client >2.0.0,<4.0.0",
         "pandas >=1.0.1,<2",
+        "prometheus_client",
         "psycopg2 >=2.8,<3",
         "pyyaml",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         "oauth2client >2.0.0,<4.0.0",
         "pandas >=1.0.1,<2",
         "prometheus_client",
+        "prometheus_flask_exporter",
         "psycopg2 >=2.8,<3",
         "pyyaml",
         "requests",


### PR DESCRIPTION
Adds platform metrics (e.g. process, Python, and GC stats) to the metrics collected. Requires a special multiprocess writer to do so. Not fully baked. Forked from an earlier version of #245 (wip/trs/metrics) and must be rebased onto that first.