### PR TITLE
Add sample editor role to database

### DIFF
--- a/schema/deploy/roles/sample-editor/create.sql
+++ b/schema/deploy/roles/sample-editor/create.sql
@@ -1,0 +1,10 @@
+-- Deploy seattleflu/schema:roles/sample-editor/create to pg
+
+begin;
+
+create role "sample-editor";
+
+comment on role "sample-editor" is 'For adding and updating sample records';
+
+
+commit;

--- a/schema/deploy/roles/sample-editor/grants.sql
+++ b/schema/deploy/roles/sample-editor/grants.sql
@@ -1,0 +1,25 @@
+-- Deploy seattleflu/schema:roles/sample-editor/grants to pg
+-- requires: roles/sample-editor/create
+-- requires: warehouse/sample
+
+begin;
+
+grant connect on database :"DBNAME" to "sample-editor";
+
+grant usage
+   on schema warehouse
+   to "sample-editor";
+
+grant select
+   on warehouse.identifier
+   to "sample-editor";
+
+grant select
+   on warehouse.identifier_set
+   to "sample-editor";
+
+grant select, insert, update
+   on warehouse.sample
+   to "sample-editor";
+
+commit;

--- a/schema/revert/roles/sample-editor/create.sql
+++ b/schema/revert/roles/sample-editor/create.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:roles/sample-editor/create from pg
+
+begin;
+
+drop role "sample-editor";
+
+commit;

--- a/schema/revert/roles/sample-editor/grants.sql
+++ b/schema/revert/roles/sample-editor/grants.sql
@@ -1,0 +1,9 @@
+-- Revert seattleflu/schema:roles/sample-editor/grants from pg
+
+begin;
+
+revoke all on database :"DBNAME" from "sample-editor";
+revoke all on schema receiving, warehouse, shipping from "sample-editor";
+revoke all on all tables in schema receiving, warehouse, shipping from "sample-editor";
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -233,3 +233,7 @@ warehouse/identifier-set/use [warehouse/identifier warehouse/identifier-set-use]
 warehouse/identifier-set/use-not-null 2021-07-06T22:26:14Z Dave Reinhart <davidrr@uw.edu> # Add not null to identifier-set use column
 warehouse/identifier/indexes/identifier_set_id_btree 2021-07-06T22:33:41Z Dave Reinhart <davidrr@uw.edu> # Add index to identifier on identifier_set_id column
 @2021-07-06 2021-07-06T22:38:05Z Dave Reinhart <davidrr@uw.edu> # Schema as of 06 Jul 2021
+
+roles/sample-editor/create 2021-08-13T15:01:31Z Dave Reinhart <davidrr@uw.edu> # Add sample editor role
+roles/sample-editor/grants 2021-08-13T15:03:19Z Dave Reinhart <davidrr@uw.edu> # Grant permissions to sample-editor role
+@2021-08-13 2021-08-13T15:15:55Z Dave Reinhart <davidrr@uw.edu> # Schema as of 13 Aug 2021

--- a/schema/verify/roles/sample-editor/create.sql
+++ b/schema/verify/roles/sample-editor/create.sql
@@ -1,0 +1,8 @@
+-- Verify seattleflu/schema:roles/sample-editor/create on pg
+
+begin;
+
+-- No real need to test that the user was created; the database would have
+-- thrown an error if it wasn't.
+
+rollback;

--- a/schema/verify/roles/sample-editor/grants.sql
+++ b/schema/verify/roles/sample-editor/grants.sql
@@ -1,0 +1,16 @@
+-- Verify seattleflu/schema:roles/sample-editor/grants on pg
+
+begin;
+
+select 1/pg_catalog.has_database_privilege('sample-editor', :'DBNAME', 'connect')::int;
+select 1/pg_catalog.has_schema_privilege('sample-editor', 'warehouse', 'usage')::int;
+select 1/pg_catalog.has_table_privilege('sample-editor', 'warehouse.identifier', 'select')::int;
+select 1/pg_catalog.has_table_privilege('sample-editor', 'warehouse.identifier_set', 'select')::int;
+select 1/pg_catalog.has_table_privilege('sample-editor', 'warehouse.sample', 'select,insert,update')::int;
+
+select 1/(not pg_catalog.has_schema_privilege('sample-editor', 'receiving', 'usage'))::int;
+select 1/(not pg_catalog.has_table_privilege('sample-editor', 'warehouse.identifier', 'insert,update,delete'))::int;
+select 1/(not pg_catalog.has_table_privilege('sample-editor', 'warehouse.identifier_set', 'insert,update,delete'))::int;
+select 1/(not pg_catalog.has_table_privilege('sample-editor', 'warehouse.sample', 'delete'))::int;
+
+rollback;


### PR DESCRIPTION
Initially for use with LIMS, this role will be used to insert and
update records in the `warehouse.sample` table as well as verify
barcodes and uses in `warehouse.identifier` and `identifier_set` tables
via ID3C API.