### PR TITLE
Adding sample GET endpoint to API

### DIFF
--- a/lib/id3c/api/datastore.py
+++ b/lib/id3c/api/datastore.py
@@ -239,7 +239,7 @@ def fetch_identifier(session: DatabaseSession, id: str) -> Any:
             """, (id,))
 
     if not identifier:
-        LOG.error(f"Identifier {id_field} «{id}» not found")
+        LOG.info(f"Identifier {id_field} «{id}» not found")
         raise NotFound(f"Identifier {id_field} «{id}» not found")
 
     return identifier
@@ -281,7 +281,7 @@ def fetch_identifier_set(session: DatabaseSession, name: str) -> Any:
             """, (name,))
 
     if not set:
-        LOG.error(f"Identifier set «{name}» not found")
+        LOG.info(f"Identifier set «{name}» not found")
         raise NotFound(f"Identifier set «{name}» not found")
 
     return set
@@ -399,18 +399,18 @@ def get_sample(session: DatabaseSession, barcode: str) -> Any:
     """
 
     with session:
-        sample_identifier = find_identifier(session, barcode) or None
+        identifier = find_identifier(session, barcode) or None
 
-        if not sample_identifier:
-            LOG.error(f"Identifier barcode «{barcode}» not found")
+        if not identifier:
+            LOG.info(f"Identifier barcode «{barcode}» not found")
             raise NotFound(f"Identifier barcode «{barcode}» not found")
-        elif sample_identifier.set_use=='sample':
+        elif identifier.set_use=='sample':
             identifier_field = sql.Identifier('identifier')
-        elif sample_identifier.set_use=='collection':
+        elif identifier.set_use=='collection':
             identifier_field = sql.Identifier('collection_identifier')
         else:
-            error_msg = f"Identifier barcode «{barcode}» has use type «{sample_identifier.set_use}» instead of expected use type «sample» or «collection»"
-            LOG.error(error_msg)
+            error_msg = f"Identifier barcode «{barcode}» has use type «{identifier.set_use}» instead of expected use type «sample» or «collection»"
+            LOG.info(error_msg)
             raise Conflict(error_msg)
             
         query = sql.SQL("""
@@ -420,10 +420,10 @@ def get_sample(session: DatabaseSession, barcode: str) -> Any:
             where {field} = %s
             """).format(field=identifier_field)
 
-        sample = session.fetch_row(query, (sample_identifier.uuid,))
+        sample = session.fetch_row(query, (identifier.uuid,))
     
     if not sample:
-        raise NotFound(f"Sample record with {sample_identifier.set_use} identifier barcode «{barcode}» not found")
+        raise NotFound(f"Sample record with {identifier.set_use} identifier barcode «{barcode}» not found")
     else:
         return sample
 

--- a/lib/id3c/api/datastore.py
+++ b/lib/id3c/api/datastore.py
@@ -385,7 +385,7 @@ def fetch_identifier_set_uses(session: DatabaseSession) -> Any:
 
 @export
 @catch_permission_denied
-def get_sample(session: DatabaseSession, barcode: str) -> Any:
+def get_sample(session: DatabaseSession, barcode: str, barcode_type: str) -> Any:
     """
     Fetch the sample with identifier or collection identifier matching *barcode* from the backing
     database using *session*.
@@ -404,6 +404,8 @@ def get_sample(session: DatabaseSession, barcode: str) -> Any:
         if not identifier:
             LOG.info(f"Identifier barcode «{barcode}» not found")
             raise NotFound(f"Identifier barcode «{barcode}» not found")
+        elif identifier.set_use!=barcode_type and identifier.set_use in ('sample', 'collection'):
+            raise NotFound(f"Identifier use «{barcode_type}» does not match identifier use «{identifier.set_use}» of barcode")
         elif identifier.set_use=='sample':
             identifier_field = sql.Identifier('identifier')
         elif identifier.set_use=='collection':

--- a/lib/id3c/api/routes.py
+++ b/lib/id3c/api/routes.py
@@ -266,6 +266,21 @@ def get_identifier_set_uses(*, session):
 
     return jsonify([ use._asdict() for use in uses ])
 
+@api_v1.route("/warehouse/sample/<barcode>", methods = ['GET'])
+@authenticated_datastore_session_required
+def get_sample(barcode, *, session):
+    """
+    Retrieve a sample's metadata.
+
+    GET /warehouse/sample/*barcode* to receive a JSON object containing the
+    sample's record.
+    """
+    LOG.debug(f"Fetching sample with barcode «{barcode}»")
+
+    sample = datastore.get_sample(session, barcode)
+
+    return jsonify(sample._asdict())
+
 @api_v1.route("/warehouse/sample", methods = ['POST'])
 @content_types_accepted(["application/json"])
 @check_content_length

--- a/lib/id3c/api/routes.py
+++ b/lib/id3c/api/routes.py
@@ -266,18 +266,28 @@ def get_identifier_set_uses(*, session):
 
     return jsonify([ use._asdict() for use in uses ])
 
+@api_v1.route("/warehouse/sample", methods = ['GET'])
 @api_v1.route("/warehouse/sample/<barcode>", methods = ['GET'])
 @authenticated_datastore_session_required
-def get_sample(barcode, *, session):
+def get_sample(barcode=None, *, session):
     """
     Retrieve a sample's metadata.
 
     GET /warehouse/sample/*barcode* to receive a JSON object containing the
-    sample's record.
+    sample record with the provided sample barcode.
+
+    GET /warehouse/sample?collection_barcode=*barcode* to receive a JSON object
+    containing the sample record with the provided collection barcode.
     """
+    if not barcode:
+        barcode = request.args.get('collection_barcode')
+        barcode_type = 'collection'
+    else:
+        barcode_type = 'sample'
+
     LOG.debug(f"Fetching sample with barcode «{barcode}»")
 
-    sample = datastore.get_sample(session, barcode)
+    sample = datastore.get_sample(session, barcode, barcode_type)
 
     return jsonify(sample._asdict())
 

--- a/lib/id3c/api/static/index.html
+++ b/lib/id3c/api/static/index.html
@@ -95,6 +95,12 @@
     parameter is required for new sets and is optional if only updating
     <em>description</em> on an existing set.
 
+    <h3 class="code">GET /v1/warehouse/sample/<em>&lt;barcode&gt;</em></h3>
+    <p>Retrieve metadata about a sample record by sample barcode.
+
+    <h3 class="code">GET /v1/warehouse/sample?collection_barcode=<em>&lt;barcode&gt;</em></h3>
+    <p>Retrieve metadata about a sample record by collection barcode.
+  
     <h3 class="code">POST /v1/warehouse/sample</h3>
     <p>Insert or update a sample record.
     <p>The body of the request should be a JSON object with the following format:


### PR DESCRIPTION
Provides ability to retrieve sample records using a GET request which
will be useful in conjunction with the `warehouse/sample` POST endpoint,
to view records before and after updating them through the API.