### PR TITLE
Add date to sample API to be written to details

### DIFF
--- a/lib/id3c/api/datastore.py
+++ b/lib/id3c/api/datastore.py
@@ -424,7 +424,10 @@ def store_sample(session: DatabaseSession, sample: dict) -> Any:
             return result
 
         collected_date = sample.get("collection_date", None)
-
+        
+        # Add date to sample so that it gets written to the 'details' column in warehouse.sample
+        sample["date"] = collected_date
+        
         # When updating an existing row, update the identifiers only if the record has both
         # the 'sample_barcode' and 'collection_barcode' keys
         should_update_identifiers = True if (sample_identifier and collection_identifier) else False


### PR DESCRIPTION
Date should be included in `warehouse.sample` jsonb column `details`.
Adding here to match process in manifest ETL and ensure this value
is present for queries (and alerts) that rely on it.