### PR TITLE
Rename CLIA ID in sample details to match existing data

### DIFF
--- a/lib/id3c/api/datastore.py
+++ b/lib/id3c/api/datastore.py
@@ -428,6 +428,10 @@ def store_sample(session: DatabaseSession, sample: dict) -> Any:
         # Add date to sample so that it gets written to the 'details' column in warehouse.sample
         sample["date"] = collected_date
         
+        # Rename clia_id to clia_barcode to include in 'details' column in warehouse.sample
+        if "clia_id" in sample:
+            sample["clia_barcode"] = sample.pop("clia_id")
+
         # When updating an existing row, update the identifiers only if the record has both
         # the 'sample_barcode' and 'collection_barcode' keys
         should_update_identifiers = True if (sample_identifier and collection_identifier) else False


### PR DESCRIPTION
The manifest ETL renames the `clia_id` from worksheet to `clia_barcode` before storing
in sample details. Updating API endpoint here to match, so that data submitted
through the API matches format of data previously ingested from the manifest worksheets.

The `clia_barcode` key name is also used in shipping views so this will ensure it
is populating correctly there and will appear in related automated Slack alerts.