### PR TITLE
update the 'Setup' link TOC in the Readme.md to point at renamed section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Data logistics system enabling real-time genomic epidemiology. Built for the
 * [Database](#database)
 * [Web API](#web-api)
 * [CLI](#cli)
-* [Setup](#setup)
-* [Dev tools](#dev-tools)
+* [Development Setup](#development-setup)
 
 ## Database
 


### PR DESCRIPTION
During the update of the readme.md in #223 , some of the items were renamed but not reflected in the TOC. I went ahead and dropped the 'Dev-tools' and updated the link for 'Setup'. 