### PR TITLE
Convert Smartystreets extract lookups to Latin-1 charset

### DIFF
--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -396,6 +396,9 @@ def extract_address(address: dict) -> dict:
     if not address_text.strip():
         return None
 
+    address_bytes = address_text.encode('utf8')
+    address_text = address_bytes.decode('latin1')
+
     lookup = ExtractLookup()
     lookup.text = address_text
 


### PR DESCRIPTION
Convert all extract lookups via Smartystreets from UTF-8 to a bytestring and then back to Latin-1. This should resolve the UnicodeEncodeError we get when Unicode-only characters are entered into addresses (particularly punctuation).

Searching Slack for instances of UnicodeEncodeError shows that whenever it happens in Smartystreets, it's always in the `extract_address()` function, so no need to add it to the `geocode_address()` function, at least for now.

When a Unicode-only character is converted in this way, the character itself will not be preserved, e.g. the Unicode character `，` is converted to the Latin-1 characters `ï¼\x8c` (the `\x8c` is a nonprintable character). However, my testing indicated that Smartystreets was still able to return results in that case.

This should always succeed, because Python strings are naturally Unicode, and any valid Unicode should be encodeable as a bytestring. Any valid bytestring should then be decodeable to Latin-1, each character of which is 1 byte. If it ever fails, we definitely want to know about it, so it should break as noisily as possible.