### PR TITLE
Adds more control over how collection date is assigned.

### DIFF
--- a/lib/id3c/api/datastore.py
+++ b/lib/id3c/api/datastore.py
@@ -444,6 +444,7 @@ def store_sample(session: DatabaseSession, sample: dict) -> Any:
         try:
             sample, status = upsert_sample(session,
                     update_identifiers          = should_update_identifiers,
+                    overwrite_collection_date   = True,
                     identifier                  = sample_identifier.uuid if sample_identifier else None,
                     collection_identifier       = collection_identifier.uuid if collection_identifier else None,
                     collection_date             = collected_date,

--- a/lib/id3c/cli/command/etl/enrollments.py
+++ b/lib/id3c/cli/command/etl/enrollments.py
@@ -166,12 +166,13 @@ def process_samples(db: DatabaseSession,
         }
 
         upsert_sample(db,
-            update_identifiers    = False,
-            identifier            = None,
-            collection_identifier = identifier.uuid,
-            collection_date       = None,
-            encounter_id          = encounter_id,
-            additional_details    = details)
+            update_identifiers          = False,
+            overwrite_collection_date   = False,
+            identifier                  = None,
+            collection_identifier       = identifier.uuid,
+            collection_date             = None,
+            encounter_id                = encounter_id,
+            additional_details          = details)
 
     # XXX TODO: Should this delete existing linked samples which
     # weren't mentioned in this enrollment document?  This would

--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -673,12 +673,13 @@ def process_encounter_samples(db: DatabaseSession, encounter: Encounter, encount
         # XXX TODO: Improve details object here; the current approach produces
         # an object like {"coding": [{…}]} which isn't very useful.
         upsert_sample(db,
-            update_identifiers      = False,
-            identifier              = sample_identifier,
-            collection_identifier   = collection_identifier,
-            collection_date         = collection_date,
-            encounter_id            = encounter_id,
-            additional_details      = additional_details)
+            update_identifiers          = False,
+            overwrite_collection_date   = False,
+            identifier                  = sample_identifier,
+            collection_identifier       = collection_identifier,
+            collection_date             = collection_date,
+            encounter_id                = encounter_id,
+            additional_details          = additional_details)
 
 def encounter_age(encounter: Encounter, resources: Dict[str, List[DomainResource]]) -> Optional[str]:
     """

--- a/lib/id3c/cli/command/etl/manifest.py
+++ b/lib/id3c/cli/command/etl/manifest.py
@@ -176,6 +176,7 @@ def etl_manifest(*, db: DatabaseSession):
             # warehouse for each piece of information.
             sample, status = upsert_sample(db,
                 update_identifiers          = should_update_identifiers,
+                overwrite_collection_date   = True,
                 identifier                  = sample_identifier.uuid if sample_identifier else None,
                 collection_identifier       = collection_identifier.uuid if collection_identifier else None,
                 collection_date             = collected_date,


### PR DESCRIPTION
Update to upsert_sample function (which is used in multiple contexts)
to control whether or not the incoming collection_date will be used to
overwrite an existing value in the `collected` column of the sample record.

For samples updated through the API, which are coming from the lab,
the collection date will overwrite the existing value. For records coming
from FHIR ETL which originate from REDCap, the collection_date will only
be used if there is no value in the table.

The manifest and enrollments ETL are no longer in production use, but are
updated here to keep them functional.