### PR TITLE
Add error class for use in id3c-customizations clinical ETL

### DIFF
--- a/lib/id3c/cli/command/etl/__init__.py
+++ b/lib/id3c/cli/command/etl/__init__.py
@@ -445,5 +445,11 @@ class UnknownFluShotResponseError(ValueError):
     """
     pass
 
+class UnknownCovidScreenError(ValueError):
+    """
+    Raised by :function:`covid_screen` if its provided *is_covid_screen* is not
+    among the set of expected values.
+    """
+    pass
 
 from . import *


### PR DESCRIPTION
A new value `covid_screen` is being ingested from SCH Clinical data that
identifies samples that were collected for screening purposes only.

This error will initially be used in clinical ETL of id3c-customizations
for cases of unexpected values.