### PR TITLE
Add Tiny SCAN, AFH, and Workplace Identifier Sets

### DIFF
--- a/lib/id3c/cli/command/etl/fhir.py
+++ b/lib/id3c/cli/command/etl/fhir.py
@@ -80,6 +80,9 @@ EXPECTED_COLLECTION_IDENTIFIER_SETS = [
     'collections-uw-tiny-swabs-observed',
     'collections-household-general',
     'collections-childcare',
+    "collections-scan-tiny-swabs",
+    "collections-adult-family-home-outbreak-tiny-swabs",
+    "collections-workplace-outbreak-tiny-swabs",
 ]
 EXPECTED_SAMPLE_IDENTIFIER_SETS = ['samples']
 

--- a/lib/id3c/cli/command/etl/manifest.py
+++ b/lib/id3c/cli/command/etl/manifest.py
@@ -88,6 +88,9 @@ def etl_manifest(*, db: DatabaseSession):
             "collections-workplace-outbreak",
             "collections-radxup-yakima-schools-home",
             "collections-radxup-yakima-schools-observed",
+            "collections-scan-tiny-swabs",
+            "collections-adult-family-home-outbreak-tiny-swabs",
+            "collections-workplace-outbreak-tiny-swabs",
         },
         "rdt": {"collections-fluathome.org"}
     }

--- a/lib/id3c/cli/command/etl/presence_absence.py
+++ b/lib/id3c/cli/command/etl/presence_absence.py
@@ -49,6 +49,9 @@ valid_identifiers = [
         "samples",
         "collections-uw-tiny-swabs-home",
         "collections-uw-tiny-swabs-observed",
+        "collections-scan-tiny-swabs",
+        "collections-adult-family-home-outbreak-tiny-swabs",
+        "collections-workplace-outbreak-tiny-swabs",
 ]
 
 @etl.command("presence-absence", help = __doc__)

--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -359,16 +359,16 @@ class CollectionsScanTinySwabsLayout(LabelLayout):
     reference = "scanpublichealth.org" 
 
 
-class CollectionsAdultFamilyHomeOutbreakTinyLayout(LabelLayout):
+class CollectionsAdultFamilyHomeOutbreakTinySwabsLayout(LabelLayout):
     sku = "LCRY-2380"
-    barcode_type = 'AFH-TS'
+    barcode_type = 'AFH TINY'
     copies_per_barcode = 1
     reference = "seattleflu.org"
 
 
-class CollectionsWorkplaceOutbreakTinyLayout(LabelLayout):
+class CollectionsWorkplaceOutbreakTinySwabsLayout(LabelLayout):
     sku = "LCRY-2380"
-    barcode_type = 'WORKPLACE-TS'
+    barcode_type = 'WORK TINY'
     copies_per_barcode = 1
     reference = "seattleflu.org"
 
@@ -409,8 +409,8 @@ LAYOUTS = {
     'collections-uw-tiny-swabs-home': CollectionsUWTinySwabsHomeLayout,
     'collections-uw-tiny-swabs-observed': CollectionsUWTinySwabsObservedLayout,
     'collections-scan-tiny-swabs': CollectionsScanTinySwabsLayout,
-    'collections-adult-family-home-outbreak-tiny-swabs': CollectionsAdultFamilyHomeOutbreakTinyLayout,
-    'collections-workplace-outbreak-tiny-swabs': CollectionsWorkplaceOutbreakTinyLayout
+    'collections-adult-family-home-outbreak-tiny-swabs': CollectionsAdultFamilyHomeOutbreakTinySwabsLayout,
+    'collections-workplace-outbreak-tiny-swabs': CollectionsWorkplaceOutbreakTinySwabsLayout
 }
 
 

--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -351,6 +351,28 @@ class CollectionsUWTinySwabsObservedLayout(LabelLayout):
     copies_per_barcode = 1
     reference = "seattleflu.org"
 
+
+class CollectionsScanTinySwabsLayout(LabelLayout):
+    sku = "LCRY-2380"
+    barcode_type = 'SCAN TINY'
+    copies_per_barcode = 1
+    reference = "scanpublichealth.org" 
+
+
+class CollectionsAdultFamilyHomeOutbreakTinyLayout(LabelLayout):
+    sku = "LCRY-2380"
+    barcode_type = 'AFH-TS'
+    copies_per_barcode = 1
+    reference = "seattleflu.org"
+
+
+class CollectionsWorkplaceOutbreakTinyLayout(LabelLayout):
+    sku = "LCRY-2380"
+    barcode_type = 'WORKPLACE-TS'
+    copies_per_barcode = 1
+    reference = "seattleflu.org"
+
+
 LAYOUTS = {
     "samples": SamplesLayout,
     "collections-scan": CollectionsScanLayout,
@@ -386,6 +408,9 @@ LAYOUTS = {
     'collections-uw-tiny-swabs': CollectionsUWTinySwabsLayout,
     'collections-uw-tiny-swabs-home': CollectionsUWTinySwabsHomeLayout,
     'collections-uw-tiny-swabs-observed': CollectionsUWTinySwabsObservedLayout,
+    'collections-scan-tiny-swabs': CollectionsScanTinySwabsLayout,
+    'collections-adult-family-home-outbreak-tiny-swabs': CollectionsAdultFamilyHomeOutbreakTinyLayout,
+    'collections-workplace-outbreak-tiny-swabs': CollectionsWorkplaceOutbreakTinyLayout
 }
 
 


### PR DESCRIPTION
To support the new tiny swab format for the following studies, SCAN, Adult Family Homes, and Workplace:
1. their barcode layout is added to labelmaker.py
2. their identifiers is added to the presence_absence ETL