### PR TITLE
Prevent local smartystreets usage

### DIFF
--- a/lib/id3c/cli/command/__init__.py
+++ b/lib/id3c/cli/command/__init__.py
@@ -169,9 +169,9 @@ def pickled_cache(filename: str = None) -> Iterator[TTLCache]:
         try:
             with open(filename, "rb") as file:
                 cache = pickle.load(file)
-        except FileNotFoundError:
-            LOG.warning(f"Cache file «{filename}» does not exist; starting with empty cache.")
-            cache = empty_cache
+        except FileNotFoundError as error:
+            LOG.error(f"Cache file «{filename}» does not exist, please provide a valid cache.")
+            raise error from None
         else:
             assert isinstance(cache, TTLCache), \
                 f"Cache file contains a {cache!r}, not a TTLCache"

--- a/lib/id3c/cli/command/__init__.py
+++ b/lib/id3c/cli/command/__init__.py
@@ -142,7 +142,7 @@ def with_database_session(command = None, *, pass_action: bool = False):
 
 
 @contextmanager
-def pickled_cache(filename: str = None) -> Iterator[TTLCache]:
+def pickled_cache(filename: str = None, create_if_missing: bool = False) -> Iterator[TTLCache]:
     """
     Context manager for reading/writing a :class:`TTLCache` from/to the given
     *filename*.
@@ -155,10 +155,14 @@ def pickled_cache(filename: str = None) -> Iterator[TTLCache]:
     If no *filename* is provided, a transient, in-memory cache is returned
     instead.
 
-    >>> with pickled_cache("/tmp/id3c-geocoding.cache") as cache:
+    If a *filename* is provided that does not currently exist, and create_if_missing
+    is `True`, a new cache file will be created. If the provided *filename* does not
+    exist and create_if_missing is `False`, an error will be raised. 
+
+    >>> with pickled_cache("/tmp/id3c-geocoding.cache", True) as cache:
     ...     cache["key1"] = "value1"
 
-    >>> with pickled_cache("/tmp/id3c-geocoding.cache") as cache:
+    >>> with pickled_cache("/tmp/id3c-geocoding.cache", True) as cache:
     ...     print(cache["key1"])
     value1
     """
@@ -170,8 +174,12 @@ def pickled_cache(filename: str = None) -> Iterator[TTLCache]:
             with open(filename, "rb") as file:
                 cache = pickle.load(file)
         except FileNotFoundError as error:
-            LOG.error(f"Cache file «{filename}» does not exist, please provide a valid cache.")
-            raise error from None
+            if create_if_missing:
+                LOG.warning(f"Cache file «{filename}» does not exist; starting with empty cache.")
+                cache = empty_cache
+            else:
+                LOG.error(f"Cache file «{filename}» does not exist, please provide a valid cache.")
+                raise error from None
         else:
             assert isinstance(cache, TTLCache), \
                 f"Cache file contains a {cache!r}, not a TTLCache"

--- a/lib/id3c/cli/command/etl/redcap_det.py
+++ b/lib/id3c/cli/command/etl/redcap_det.py
@@ -104,7 +104,7 @@ def command_for_project(name: str,
             metavar = "<cache.pickle>",
             envvar = "GEOCODING_CACHE",
             help = "Local file for caching the results of address geocoding. Geocoding lookups will not be cached otherwise.",
-            required = False,
+            required = True,
             type = click.Path(dir_okay=False, writable=True))
 
         @redcap_det.command(name, **kwargs)


### PR DESCRIPTION
Changes to make it more difficult to use SmartyStreets credits during local development. This has occurred multiple times while testing REDCap DET ETL processes locally, causing unnecessary usage.

The geocoding cache file will now be required, and will fail if the specified file is not found. The other change is that the user will be prompted prior to any requests being sent to the SmartyStreets API, if geocoding in a non-production environment. This will help ensure that use of the geocoding service during local development is more visible and intentional.