### PR TITLE
Adding Github action to automatically publish to pypi

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,37 @@
+name: CD
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python distributions to PyPI and TestPyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+    - name: Publish distribution to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ Thumbs.db
 
 # IDE files
 /.vscode
+
+# Build and dist files
+build/
+dist/


### PR DESCRIPTION
Publishing id3c to pypi will help standardize how this package is being
installed compared to other dependencies. This will make the package simpler
include in multiple applications and pin to a specific version when needed.

One workflow change this will require is that commits on master branch will need to
be tagged to be published to pypi.org (whereas all commits on master branch will be
published to test.pypi.org). A version naming convention will need to be
decided on and integrated into the deployment workflow, but the specific format
chosen will not impact this PR.