### PR TITLE
Add timeout to REDCap requests

### DIFF
--- a/lib/id3c/cli/redcap.py
+++ b/lib/id3c/cli/redcap.py
@@ -494,7 +494,7 @@ class Project:
         # in many cases succeeds with additional attempts.
         # -drr, 7/28/2021
         while retry_count <= max_retry_count:
-            response = requests.post(self.api_url, data=data, headers=headers)
+            response = requests.post(self.api_url, data=data, headers=headers, timeout=300)
             if response.status_code==200 and 'multiple browser tabs of the same REDCap page. If that is not the case' in response.text:
                 retry_count += 1
                 LOG.debug(f"Retrying REDCap API request: {retry_count}/{max_retry_count}")


### PR DESCRIPTION
A 300 second timeout is being added to all REDCap requests, which ultimately
all use the _fetch function. It has been confirmed there is 120 second timeout on the
server side so this should be plenty of extra time before giving up on a request.

The goal of this change is to prevent requests from hanging indefinitely, and to
throw an exception when a request exceeds 5 minutes.