### PR TITLE
Adding ValueError classes for COVID vaccination status and manufacturer

### DIFF
--- a/lib/id3c/cli/command/etl/__init__.py
+++ b/lib/id3c/cli/command/etl/__init__.py
@@ -452,4 +452,18 @@ class UnknownCovidScreenError(ValueError):
     """
     pass
 
+class UnknownCovidShotResponseError(ValueError):
+    """
+    Raised by :function:`covid_shot` if its provided *covid_shot_response* is not
+    among the set of expected values.
+    """
+    pass
+
+class UnknownCovidShotManufacturerError(ValueError):
+    """
+    Raised by :function:`covid_shot_manufacturer` if its provided *covid_shot_manufacturer_name* is not
+    among the set of expected values.
+    """
+    pass
+
 from . import *


### PR DESCRIPTION
These will be used in `id3c-customizations` as part of the clinical ETL.
New data was recieved for SCH that includes COVID vaccination status and
manufacturer which will be ingested into ID3C. These errors will be raised
if unreconized values are encountered during the ETL process.