### PR TITLE
Add Fred Hutch AIRS Identifier Set

### DIFF
--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -372,6 +372,11 @@ class CollectionsWorkplaceOutbreakTinySwabsLayout(LabelLayout):
     copies_per_barcode = 1
     reference = "seattleflu.org"
 
+class CollectionsAirsLayout(LabelLayout):
+    sku = "LCRY-1100"
+    barcode_type = 'AIRS'
+    copies_per_barcode = 2
+    reference = "fredhutch.org"
 
 LAYOUTS = {
     "samples": SamplesLayout,
@@ -410,7 +415,8 @@ LAYOUTS = {
     'collections-uw-tiny-swabs-observed': CollectionsUWTinySwabsObservedLayout,
     'collections-scan-tiny-swabs': CollectionsScanTinySwabsLayout,
     'collections-adult-family-home-outbreak-tiny-swabs': CollectionsAdultFamilyHomeOutbreakTinySwabsLayout,
-    'collections-workplace-outbreak-tiny-swabs': CollectionsWorkplaceOutbreakTinySwabsLayout
+    'collections-workplace-outbreak-tiny-swabs': CollectionsWorkplaceOutbreakTinySwabsLayout,
+    'collections-airs': CollectionsAirsLayout
 }
 
 


### PR DESCRIPTION
In anticipation of the new study, FH Prospective Sero Study AIM 3B, the identifier set 'collections-airs' is added.

Changes were tested via 'dry-run' and output file was expected based on the specs of the study's requester.

UPDATE: Study's requester has confirmed that the barcode minted is what they want visually. 