### PR TITLE
Add Cascadia Identifiers Set

### DIFF
--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -356,7 +356,7 @@ class CollectionsScanTinySwabsLayout(LabelLayout):
     sku = "LCRY-2380"
     barcode_type = 'SCAN TINY'
     copies_per_barcode = 1
-    reference = "scanpublichealth.org" 
+    reference = "scanpublichealth.org"
 
 
 class CollectionsAdultFamilyHomeOutbreakTinySwabsLayout(LabelLayout):
@@ -377,6 +377,12 @@ class CollectionsAirsLayout(LabelLayout):
     barcode_type = 'AIRS'
     copies_per_barcode = 2
     reference = "fredhutch.org"
+
+class CollectionsCascadiaTinySwabsHome(SamplesLayout):
+    sku = "LCRY-2380"
+    barcode_type = 'CASCADIA'
+    copies_per_barcode = 2
+    reference = "cascadiastudy.org"
 
 LAYOUTS = {
     "samples": SamplesLayout,
@@ -416,7 +422,8 @@ LAYOUTS = {
     'collections-scan-tiny-swabs': CollectionsScanTinySwabsLayout,
     'collections-adult-family-home-outbreak-tiny-swabs': CollectionsAdultFamilyHomeOutbreakTinySwabsLayout,
     'collections-workplace-outbreak-tiny-swabs': CollectionsWorkplaceOutbreakTinySwabsLayout,
-    'collections-airs': CollectionsAirsLayout
+    'collections-airs': CollectionsAirsLayout,
+    'collections-cascadia-tiny-swabs-home': CollectionsCascadiaTinySwabsHome
 }
 
 

--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -96,11 +96,9 @@ class LCRY1100TriplicateLayout(LabelLayout):
         return 1 if barcode_number > 1 else 0
 
 
-class SamplesLayout(LabelLayout):
+class LCRY2380DuplicateLayout(LabelLayout):
     sku = "LCRY-2380"
-    barcode_type = "SAMPLE"
     copies_per_barcode = 2
-    reference = "seattleflu.org"
 
     def blanks_before(self, barcode_number):
         """
@@ -112,6 +110,11 @@ class SamplesLayout(LabelLayout):
         blank, it starts filling in from the 1st label of the next row).
         """
         return 1 if barcode_number > 1 and (barcode_number - 1) % 3 == 0 else 0
+
+
+class SamplesLayout(LCRY2380DuplicateLayout):
+    barcode_type = "SAMPLE"
+    reference = "seattleflu.org"
 
 
 class CollectionsSeattleFluLayout(LabelLayout):
@@ -378,10 +381,8 @@ class CollectionsAirsLayout(LabelLayout):
     copies_per_barcode = 2
     reference = "fredhutch.org"
 
-class CollectionsCascadiaTinySwabsHome(SamplesLayout):
-    sku = "LCRY-2380"
+class CollectionsCascadiaTinySwabsHome(LCRY2380DuplicateLayout):
     barcode_type = 'CASCADIA'
-    copies_per_barcode = 2
     reference = "cascadiastudy.org"
 
 LAYOUTS = {


### PR DESCRIPTION
In anticipation of the Cascadia study, this change adds the
identifier set `collections-cascadia-tiny-swabs-home`. Because
this set uses duplicate tiny barcodes, this collection set
inserts a blank barcode before each 4th barcode to keep the
last column empty and duplicate barcodes next to each other.

This change was tested locally by doing a dry run of minting barcodes for the new identifier, which output barcodes in the correct format (51 pairs of duplicates per sheet, with the last column blank, for a total of 1,020 barcodes per 20 sheets).

Update: Barcodes were tested and printed and look good to the requesters.