### PR TITLE
SCH Retro Additional Fields/Values Ingestion

### DIFF
--- a/lib/id3c/cli/command/etl/__init__.py
+++ b/lib/id3c/cli/command/etl/__init__.py
@@ -466,4 +466,18 @@ class UnknownCovidShotManufacturerError(ValueError):
     """
     pass
 
+class UnknownAdmitEncounterResponseError(ValueError):
+    """
+    Raised by :function:`admit_encounter` if its provided *admit_encounter_response* is not
+    among the set of expected values.
+    """
+    pass
+
+class UnknownAdmitICUResponseError(ValueError):
+    """
+    Raised by :function:`admit_icu` if its provided *admit_icu_response* is not
+    among the set of expected values.
+    """
+    pass
+
 from . import *


### PR DESCRIPTION
Related to ingesting additional Seattle Children's fields, `admit_to_icu` and `admit_during_this_encounter` and convert response to `yes` or `no`.

Refer to id3c-customization': https://github.com/seattleflu/id3c-customizations/pull/283