### PR TITLE
Rework gitignore to function as allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,27 @@
-*.pyc
-__pycache__/
-/.mypy_cache/
-/lib/id3c.egg-info/
-/build/
+# Ignore everything
+*
 
-# pyproject.toml is auto-generated when using pipenv>=2020.11.15, added here
-# to avoid having it deployed until production is updated to that version
-pyproject.toml
+# except these files
+!/.gitignore
+!/LICENSE
+!/README.md
+!/DEVELOPMENT.md
+!/Pipfile
+!/Pipfile.lock
+!/pytest.ini
+!/setup.py
+!/sqitch.conf
+!/wsgi.py
 
-# Some OS-generated files that should really be in people's global git
-# excludes, but which we proactively make sure don't enter the repo here.
-.DS_Store
-.DS_Store?
-._*
-.Spotlight-V100
-.Trashes
-Icon?
-ehthumbs.db
-Thumbs.db
+# and these directories
+!/bin/
+!/dev/
+!/docs/
+!/lib/
+!/schema/
+!/tests/
 
-# IDE files
-/.vscode
-
-# ignore data files that may have erroneously remained in this directory
-*.csv
-*.ndjson
-*.xls
-*.xlsx
+# and these nested files
+!/.github/
+!/.github/workflows/
+!/.github/workflows/ci.yaml

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/id3c

--- a/dev/doc/.gitignore
+++ b/dev/doc/.gitignore
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/*.md
+
+# and these directories
+!/design-2019-summer/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/CODEOWNERS

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,8 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+
+# and these directories
+!/id3c/

--- a/lib/id3c/.gitignore
+++ b/lib/id3c/.gitignore
@@ -1,0 +1,14 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/py.typed
+
+# and these files ...
+!*.py
+!*.yaml
+!index.html
+
+# ... even if in subdirectories
+!/**/

--- a/schema/.gitignore
+++ b/schema/.gitignore
@@ -1,0 +1,13 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/sqitch.plan
+!setup.sql
+
+# and these directories
+!/deploy/
+!/revert/
+!/templates/
+!/verify/

--- a/schema/deploy/.gitignore
+++ b/schema/deploy/.gitignore
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!*.sql
+
+# even if in subdirectories
+!/**/

--- a/schema/revert/.gitignore
+++ b/schema/revert/.gitignore
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!*.sql
+
+# even if in subdirectories
+!/**/

--- a/schema/templates/.gitignore
+++ b/schema/templates/.gitignore
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!*.tmpl
+
+# even if in subdirectories
+!/**/

--- a/schema/verify/.gitignore
+++ b/schema/verify/.gitignore
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!*.sql
+
+# even if in subdirectories
+!/**/

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,6 @@
+# Ignore everything
+*
+
+# except these files
+!/.gitignore
+!/*.py


### PR DESCRIPTION
Reworking of .gitignore files to exclude everything up front, with
exceptions for files and folder that should be included. This is to
reduce the chance of pushing any files unintentionally.