### PR TITLE
Cast rows to text for data comparison in upsert_encounter

### DIFF
--- a/lib/id3c/cli/command/etl/__init__.py
+++ b/lib/id3c/cli/command/etl/__init__.py
@@ -140,13 +140,13 @@ def upsert_encounter(db: DatabaseSession,
                         encounter.site_id,
                         encounter.encountered,
                         encounter.age,
-                        regexp_replace(encounter.details::text, '"urn:uuid:[a-f0-9-]{36}"', '""', 'g'))
+                        regexp_replace(encounter.details::text, '"urn:uuid:[a-f0-9-]{36}"', '""', 'g'))::text
                     !=
                     row (%(individual_id)s::integer,
                             %(site_id)s::integer,
                             %(encountered)s::timestamp with time zone,
                             %(age)s::interval,
-                            regexp_replace((%(details)s::jsonb)::text, '"urn:uuid:[a-f0-9-]{36}"', '""', 'g'))
+                            regexp_replace(%(details)s::jsonb::text, '"urn:uuid:[a-f0-9-]{36}"', '""', 'g'))::text
                 ) as data_changed
             from warehouse.encounter
             where identifier = %(identifier)s


### PR DESCRIPTION
When comparing two items with data type `row`, the presence of a null element
within either row will return null rather than the expected boolean. This was
resulting in old encounter records continuing to be updated even though the data was not changing.

To avoid this behavior, the rows are being cast to text before comparing them.