### PR TITLE
Log changes to encounter_id when updating sample records

### DIFF
--- a/lib/id3c/db/__init__.py
+++ b/lib/id3c/db/__init__.py
@@ -233,7 +233,7 @@ def upsert_sample(db: DatabaseSession,
     if not samples:
         LOG.info("Creating new sample")
         status = 'created'
-        
+
         sample = db.fetch_row("""
             insert into warehouse.sample (identifier, collection_identifier, collected, encounter_id, details)
                 values (%(identifier)s,
@@ -250,6 +250,10 @@ def upsert_sample(db: DatabaseSession,
         sample = samples[0]
 
         LOG.info(f"Updating existing sample {sample.id}")
+
+        # Log when encounter_id is being changed to a different value
+        if encounter_id and sample.encounter_id and encounter_id != sample.encounter_id:
+            LOG.debug(f"Warning: Encounter ID is changing on sample {sample.id} from {sample.encounter_id} to {encounter_id}")
 
         # Update identifier and collection_identifier if update_identifiers is True
         identifiers_update_composable = SQL("""


### PR DESCRIPTION
Changes to the encounter_id linked to each sample may indicate an issue with the source
data, ETL, or the result of corrections being made on the source. This results in encounter
records that had previously been linked to samples to no longer be, which could indicate they
are no longer valid and can be deleted.

Adding logging at debug level to monitor how often this occurs during normal operations.
If it's reasonably low, this may be elevated to warning level. If it's occurring more
often than expected, it will require some additional investigation.