### PR TITLE
Use `cache.keys()` to cache addresses rather than Try/Catch

### DIFF
--- a/lib/id3c/cli/command/geocode.py
+++ b/lib/id3c/cli/command/geocode.py
@@ -257,10 +257,10 @@ def get_geocoded_address(address: dict,
     """
     key = json.dumps(address, sort_keys=True)
 
-    try:
+    if key in cache.keys():
         response = cache[key]
         LOG.debug('Response found in cache.')
-    except KeyError:
+    else:
         response = cache[key] = geocode_address(address)
         LOG.debug('Adding new response to cache.')
 


### PR DESCRIPTION
Using try/catch will surface a key error if an address is not in the cache.
Normally this isn't a problem, but if another exception occurs while in
the `catch` segement of an address not being in the cache the key will get
logged out. Since this key is an address, there is therefore the potential
that this address is logged on geocoding failure. This change will prevent
the actual address from being logged if there is a geocoding failure.