### PR TITLE
Fix misnamed key in `upsert_location`

### DIFF
--- a/lib/id3c/cli/command/etl/__init__.py
+++ b/lib/id3c/cli/command/etl/__init__.py
@@ -391,7 +391,7 @@ def upsert_location(db: DatabaseSession,
               values (
                 %(scale)s,
                 %(identifier)s,
-                %(location)s)
+                %(hierarchy)s)
             returning location_id as id, scale, identifier, hierarchy
             """, data
         )


### PR DESCRIPTION
When I deployed this previously I deployed with a misnamed key in one of the SQL commands.