### PR TITLE
Add index to identifier.barcode column

### DIFF
--- a/schema/deploy/warehouse/identifier/indexes/identifier_barcode_idx.sql
+++ b/schema/deploy/warehouse/identifier/indexes/identifier_barcode_idx.sql
@@ -1,0 +1,8 @@
+-- Deploy seattleflu/schema:warehouse/identifier/indexes/identifier_barcode_idx to pg
+-- requires: warehouse/identifier
+
+begin;
+
+create unique index identifier_barcode_idx on warehouse.identifier using btree (barcode);
+
+commit;

--- a/schema/revert/warehouse/identifier/indexes/identifier_barcode_idx.sql
+++ b/schema/revert/warehouse/identifier/indexes/identifier_barcode_idx.sql
@@ -1,0 +1,7 @@
+-- Revert seattleflu/schema:warehouse/identifier/indexes/identifier_barcode_idx from pg
+
+begin;
+
+drop index warehouse.identifier_barcode_idx;
+
+commit;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -237,3 +237,6 @@ warehouse/identifier/indexes/identifier_set_id_btree 2021-07-06T22:33:41Z Dave R
 roles/sample-editor/create 2021-08-13T15:01:31Z Dave Reinhart <davidrr@uw.edu> # Add sample editor role
 roles/sample-editor/grants 2021-08-13T15:03:19Z Dave Reinhart <davidrr@uw.edu> # Grant permissions to sample-editor role
 @2021-08-13 2021-08-13T15:15:55Z Dave Reinhart <davidrr@uw.edu> # Schema as of 13 Aug 2021
+
+warehouse/identifier/indexes/identifier_barcode_idx 2022-05-20T20:38:41Z Dave Reinhart <davidrr@uw.edu> # Add index to identifier.barcode column.
+@2022-05-20 2022-05-20T20:48:35Z Dave Reinhart <davidrr@uw.edu> # Schema as of 20 May 2022.

--- a/schema/verify/warehouse/identifier/indexes/identifier_barcode_idx.sql
+++ b/schema/verify/warehouse/identifier/indexes/identifier_barcode_idx.sql
@@ -1,0 +1,7 @@
+-- Verify seattleflu/schema:warehouse/identifier/indexes/identifier_barcode_idx on pg
+
+begin;
+
+
+
+rollback;


### PR DESCRIPTION
To improve performace of sort, filters, and joins that use identifier.barcode column, an
index is being added. One of the drivers for this change is to address recurring issue of
`shipping.uw_reopening_ehs_reporting_v1` view hanging indefinitely, which includes a join
with `shipping.return_results_v3` on the barcode column.