### PR TITLE
Strip Trailing Whitespace From Dumped Pandas DataFrames

### DIFF
--- a/lib/id3c/cli/io/pandas.py
+++ b/lib/id3c/cli/io/pandas.py
@@ -42,7 +42,7 @@ def dump_ndjson(df: pd.DataFrame, file = None, columns_to_mask: List[str] = None
     if columns_to_mask:
         mask_values(df, columns_to_mask)
 
-    print(df.to_json(orient = "records", lines = True, date_format = "iso"), file = file)
+    print(df.to_json(orient = "records", lines = True, date_format = "iso").rstrip(), file = file)
 
 
 def load_file_as_dataframe(filename: str) -> pd.DataFrame:


### PR DESCRIPTION
We recently upgraded from Pandas 1.1.5 to Pandas 1.4.3. In Pandas 1.2, a bug was fixed that prevented trailing whitespaces from being added to the end of dumped ndjson output. See [here](https://github.com/pandas-dev/pandas/pull/36898) for additional information.

This change uses `rstrip` (docs [here](https://docs.python.org/3/library/stdtypes.html#str.rstrip)) on the dumped ndjson output so that all trailing whitespace is removed before this data is dumped to stdout (or a destination file). Note that this trailing newline affected our assumptions about the structure of NDJSON files and thus prevented files created after the upgrade from being parsed without error.