### PR TITLE
Ignore Empty NDJSON Lines

### DIFF
--- a/lib/id3c/json.py
+++ b/lib/id3c/json.py
@@ -23,7 +23,7 @@ def load_json(value):
     messaging, compared to :exc:`json.JSONDecodeError`, when stringified.
     """
     try:
-        return json.loads(value)
+        return json.loads(value) if value else None
     except json.JSONDecodeError as e:
         raise JSONDecodeError(e) from e
 
@@ -40,7 +40,7 @@ def load_ndjson(file: Iterable[str]) -> Iterable:
     """
     Load newline-delimited JSON records from *file*.
     """
-    yield from (load_json(line) for line in file)
+    yield from (load_json(line.strip()) for line in file)
 
 
 class JsonEncoder(json.JSONEncoder):


### PR DESCRIPTION
Pandas fixed a bug that omitted trailing new lines from NDJSON dataframe output, however this caused parsing of NDJSON's to fail on the final empty line. We were originally going to handle this while dumping the NDJSON's, however it is better to use the format as intended (see #313). This change will ignore empty lines while loading NDJSON files, allowing us to use the fixed format.