### PR TITLE
Tag deprecated ETL modules

### DIFF
--- a/lib/id3c/cli/command/etl/consensus_genome.py
+++ b/lib/id3c/cli/command/etl/consensus_genome.py
@@ -1,4 +1,6 @@
 """
+Deprecated, data collection ended
+
 Process consensus genome documents into the relational warehouse.
 
 Consensus genome documents are expected to be JSONs with the following format:

--- a/lib/id3c/cli/command/etl/enrollments.py
+++ b/lib/id3c/cli/command/etl/enrollments.py
@@ -1,4 +1,6 @@
 """
+Deprecated, data collection ended
+
 Process enrollment documents into the relational warehouse
 """
 import click


### PR DESCRIPTION
Tagging enrollments and consensus genome ETLs as deprecated. These are no longer in use and have cron jobs disabled.