### PR TITLE
Update default label API URL

### DIFF
--- a/lib/id3c/labelmaker.py
+++ b/lib/id3c/labelmaker.py
@@ -12,7 +12,7 @@ from typing import Iterable
 LOG = logging.getLogger(__name__)
 
 DEFAULT_LABEL_API = os.environ.get("LABEL_API") \
-                 or "https://backoffice.seattleflu.org/labels"
+                 or "https://lab-labels.seattleflu.org"
 
 
 class LabelLayout:


### PR DESCRIPTION
The label maker API has moved to a new location. Updating to use the new location by default going forward.