### PR TITLE
Only Send Slack Message if Deletions Exist

### DIFF
--- a/lib/id3c/cli/command/redcap_sync.py
+++ b/lib/id3c/cli/command/redcap_sync.py
@@ -178,7 +178,7 @@ def delete(
 
     # Post any record deletion events to Slack to provide insight into
     # potential data deletions.
-    if post_to_slack:
+    if post_to_slack and deleted_redcap_record_identifiers:
         payload = {
             "text": "REDCap Logging API found records that may require deletion from ID3C",
             "blocks": [


### PR DESCRIPTION
Fix for #323 to only send slack messages if there are records which might need to be deleted.