### PR TITLE
Include `access_role` value in genomic sequencing ETL

### DIFF
--- a/lib/id3c/cli/command/etl/__init__.py
+++ b/lib/id3c/cli/command/etl/__init__.py
@@ -287,7 +287,7 @@ def update_sample(db: DatabaseSession,
         update warehouse.sample
             set encounter_id = %s
         where sample_id = %s
-        returning sample_id as id, identifier
+        returning sample_id as id, identifier, access_role
         """, (encounter_id, sample.id))
 
     assert sample.id, "Updating encounter_id affected no rows!"
@@ -341,7 +341,7 @@ def find_sample(db: DatabaseSession, identifier: str, for_update = True) -> Any:
         query_ending = "for update"
 
     sample = db.fetch_row("""
-        select sample_id as id, identifier, encounter_id
+        select sample_id as id, identifier, encounter_id, access_role
           from warehouse.sample
          where identifier = %s or
                collection_identifier = %s

--- a/lib/id3c/cli/command/etl/kit.py
+++ b/lib/id3c/cli/command/etl/kit.py
@@ -339,7 +339,8 @@ def find_sample(db: DatabaseSession, identifier: str) -> Optional[SampleRecord]:
         select sample_id as id,
                identifier,
                encounter_id,
-               details ->> 'sample_type' as type
+               details ->> 'sample_type' as type,
+               access_role
            from warehouse.sample
           where sample.identifier = %s
         """, (identifier,))

--- a/lib/id3c/db/types.py
+++ b/lib/id3c/db/types.py
@@ -14,12 +14,14 @@ class IdentifierRecord(NamedTuple):
 class MinimalSampleRecord(NamedTuple):
     id: int
     identifier: str
+    access_role: Optional[str]
 
 class SampleRecord(NamedTuple):
     id: int
     identifier: str
     encounter_id: Optional[int]
     type: Optional[str]
+    access_role: Optional[str]
 
 class KitRecord(NamedTuple):
     id: int
@@ -36,12 +38,14 @@ class SequenceReadSetRecord(NamedTuple):
     id: int
     sample_id: int
     urls: Optional[List[str]]
+    access_role: Optional[str]
 
 class GenomeRecord(NamedTuple):
     id: int
     sample_id: int
     organism_id: int
     sequence_read_set_id: int
+    access_role: Optional[str]
 
 class MinimalLocationRecord(NamedTuple):
     id: int


### PR DESCRIPTION
An `access_role` column was recently added to the `sample`, `sequencing_read_set`, `genomic_sequence`, and `consensus_genome` tables of the `warehouse` schema to allow data with restricted access to be included in these tables. These changes include `access_role` in the appropriate class definitions, and updates ETLs to propagate the `access_role` value from a `sample` record to the related sequencing records.

The sample record will continue server as the primary `access_role` value, but must also be stored in each table that uses row level security.